### PR TITLE
Replace hand-rolled render progress with tqdm progress bar

### DIFF
--- a/algan/render_loop.py
+++ b/algan/render_loop.py
@@ -27,6 +27,8 @@ from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
 
 import torch
+from tqdm import tqdm
+from tqdm.contrib.logging import logging_redirect_tqdm
 
 import algan.rendering.raytracing.settings as rt_settings_module
 from algan.animation_timeline.animation_contexts import Off
@@ -80,33 +82,70 @@ _PREBUILT_COLLECTION = object()
 _ACTOR_SHARE_RETREAT = 0.5
 
 
-def _emit_render_progress(done, total):
+@contextlib.contextmanager
+def _render_progress(total):
     """Report render progress on the frame the user is waiting for.
 
-    Deliberately hand-rolled rather than tqdm: Algan's output already goes
-    through ``logging`` to stderr, and a second stream writer would fight the
-    handler over the same line. On a terminal this rewrites one line in place;
-    everywhere else (pytest, CI, the render daemon) it degrades to a periodic
-    log line so captured output stays readable.
+    Yields a callable to invoke once per frame written.
+
+    On a terminal this is a tqdm bar, which buys the estimate the old in-place
+    percentage line never gave: renders run for minutes, and "22.9%" does not
+    tell you whether to wait. Everywhere else -- pytest, CI, the render daemon
+    -- it stays a periodic log line rather than tqdm's own non-TTY fallback,
+    which emits a line per update and buries a captured run in carriage
+    returns. This degrades to at most ten lines, and to silence for renders too
+    short for a progress report to tell anyone anything.
+
+    Whether to report at all is settled once, on entry, rather than per frame:
+    a bar is an object with a lifetime, so a level change mid-render can no
+    longer conjure or retire one.
     """
     if not logger.isEnabledFor(logging.INFO):
+        yield lambda: None
         return
-    if _PROGRESS_IS_TTY:
-        sys.stderr.write(
-            f"\rRendering {done}/{total} frames ({100 * done / total:5.1f}%)"
-        )
-        sys.stderr.flush()
-    elif total >= _PROGRESS_MIN_LOGGED_FRAMES and done % max(1, total // 10) == 0:
-        # Captured output gets at most ten lines, and short renders none: they
-        # finish before a progress report would tell anyone anything.
-        logger.info("Rendering %d/%d frames (%.0f%%)", done, total, 100 * done / total)
 
+    if not _PROGRESS_IS_TTY:
+        done = 0
+        step = max(1, total // 10)
 
-def _finish_render_progress():
-    """Close off an in-place progress line so the next log line starts clean."""
-    if _PROGRESS_IS_TTY and logger.isEnabledFor(logging.INFO):
-        sys.stderr.write("\n")
-        sys.stderr.flush()
+        def report_logged():
+            nonlocal done
+            done += 1
+            if total >= _PROGRESS_MIN_LOGGED_FRAMES and done % step == 0:
+                logger.info(
+                    "Rendering %d/%d frames (%.0f%%)", done, total, 100 * done / total
+                )
+
+        yield report_logged
+        return
+
+    bar = tqdm(
+        total=total,
+        desc="Rendering",
+        unit="frame",
+        file=sys.stderr,
+        dynamic_ncols=True,
+        # Global average rather than tqdm's default EWMA (smoothing=0.3).
+        # Frames do not arrive at a steady rate: the memory model sizes each
+        # batch at runtime and grows it geometrically, so a batch's frames land
+        # together and the next stalls while it preps, and an OOM retry
+        # re-renders a shrunken window. An EWMA tracks those bursts and swings
+        # the estimate hardest over the early batches, which is when people
+        # actually read it.
+        smoothing=0,
+    )
+    try:
+        # Route console logging through tqdm.write for the bar's lifetime, so a
+        # warning or a PERF batch-split mid-render prints above the bar instead
+        # of smearing it. Only handlers writing to stdout/stderr are swapped, so
+        # a user's file handler is left alone; a console handler that is not a
+        # StreamHandler at all (Manim's rich one) is out of reach and still
+        # collides. Algan's logger does not propagate, so it is redirected by
+        # name rather than reached through the root.
+        with logging_redirect_tqdm(loggers=[get_logger(), logging.root]):
+            yield lambda: bar.update(1)
+    finally:
+        bar.close()
 
 
 class EmptySceneWarning(Warning):
@@ -2811,10 +2850,9 @@ class RenderLoopMixin:
             )
             start_ind, end_ind = self.scene_times[-1]
             total_frames = max(1, end_ind - start_ind)
-            frames_done = 0
             try:
                 # Wait for the writer process to complete
-                with preserve:
+                with preserve, _render_progress(total_frames) as report_frame:
                     for frame_batch in self.get_frames(
                         *self.scene_times[-1],
                         background_color=background_color,
@@ -2826,10 +2864,8 @@ class RenderLoopMixin:
                             # After the put: the queue is bounded and feeds the
                             # encoder thread, so reporting first would run the
                             # progress ahead of the actual encode.
-                            frames_done += 1
-                            _emit_render_progress(frames_done, total_frames)
+                            report_frame()
             finally:
-                _finish_render_progress()
                 if previous_scene_times is not None:
                     self.scene_times[:] = previous_scene_times
 

--- a/laser_neural_net.py
+++ b/laser_neural_net.py
@@ -129,20 +129,38 @@ DISC_C = Color("#071827")  # the dark interior of a neuron
 # swap happens abruptly around 55%, while red bleeds into gold only near the end.
 BEAMS = [
     {"start": "#1478FF", "end": "#63CEFF", "steps": 3, "lo": 0.0, "hi": 1.0},
-    {"start": "#EDF1FF", "end": "#FF3418", "steps": 9, "lo": 0.30, "hi": 0.62,
-     "glow_scale": 0.78},  # white blooms hardest at equal glow
+    {
+        "start": "#EDF1FF",
+        "end": "#FF3418",
+        "steps": 9,
+        "lo": 0.30,
+        "hi": 0.62,
+        "glow_scale": 0.78,
+    },  # white blooms hardest at equal glow
     {"start": "#FF3A18", "end": "#FFB733", "steps": 7, "lo": 0.35, "hi": 1.05},
 ]
 
 # Arrow geometry and colours, both measured off the reference.
 ARROW_IN = {
-    "tip": 715, "tail": 544, "head_len": 41, "head_half": 19, "shaft": 7.5,
-    "head": "#57EFFE", "neck_color": "#4EE8FD", "tail_color": "#1C527D",
+    "tip": 715,
+    "tail": 544,
+    "head_len": 41,
+    "head_half": 19,
+    "shaft": 7.5,
+    "head": "#57EFFE",
+    "neck_color": "#4EE8FD",
+    "tail_color": "#1C527D",
     "glow": 0.34,
 }
 ARROW_OUT = {
-    "tip": 2500, "tail": 2634, "head_len": 32, "head_half": 16, "shaft": 6.0,
-    "head": "#FEB483", "neck_color": "#F79E74", "tail_color": "#0A1220",
+    "tip": 2500,
+    "tail": 2634,
+    "head_len": 32,
+    "head_half": 16,
+    "shaft": 6.0,
+    "head": "#FEB483",
+    "neck_color": "#F79E74",
+    "tail_color": "#0A1220",
     "glow": 0.34,
 }
 
@@ -202,8 +220,10 @@ def _neuron(x: float, y: float, scene=None) -> list:
         a1 = a0 + step * 0.5  # 50% duty cycle
         parts.append(
             Line(
-                p(x + INNER_R * math.cos(a0), y + INNER_R * math.sin(a0)) + OUT * Z_RING,
-                p(x + INNER_R * math.cos(a1), y + INNER_R * math.sin(a1)) + OUT * Z_RING,
+                p(x + INNER_R * math.cos(a0), y + INNER_R * math.sin(a0))
+                + OUT * Z_RING,
+                p(x + INNER_R * math.cos(a1), y + INNER_R * math.sin(a1))
+                + OUT * Z_RING,
                 color=dash_color,
                 border_width=stroke(INNER_W),
                 **_scene(scene),
@@ -271,10 +291,12 @@ def _hotspot(x: float, y: float, hex_color: str, glow=HOTSPOT_GLOW, scene=None):
     return Circle(
         radius=HOTSPOT_R * PX,
         location=p(x, y) + OUT * (Z_RING + Z_CORE),
-        color=Color(_towards_white(Color(hex_color)[:3].tolist(), HOTSPOT_MIX),
-                    glow=glow),
-        border_color=Color(_towards_white(Color(hex_color)[:3].tolist(), HOTSPOT_MIX),
-                           glow=glow),
+        color=Color(
+            _towards_white(Color(hex_color)[:3].tolist(), HOTSPOT_MIX), glow=glow
+        ),
+        border_color=Color(
+            _towards_white(Color(hex_color)[:3].tolist(), HOTSPOT_MIX), glow=glow
+        ),
         border_width=stroke(1.0),
         **_scene(scene),
     )
@@ -288,9 +310,7 @@ def _quad(pts, **kwargs):
     own border in its own colour.
     """
     x = torch.stack([q.reshape(-1)[:2] for q in pts])
-    area = float(
-        (x[:, 0] * x.roll(-1, 0)[:, 1] - x.roll(-1, 0)[:, 0] * x[:, 1]).sum()
-    )
+    area = float((x[:, 0] * x.roll(-1, 0)[:, 1] - x.roll(-1, 0)[:, 0] * x[:, 1]).sum())
     if area > 0:  # normalize to the clockwise-on-screen winding that fills
         pts = pts[::-1]
     return Polygon(*pts, **kwargs)
@@ -306,7 +326,14 @@ def _arrow(spec, y, scene=None):
 
     parts = [
         _quad(
-            [q + OUT * Z_RING for q in (p(x_tip, y), p(x_neck, y - head_half), p(x_neck, y + head_half))],
+            [
+                q + OUT * Z_RING
+                for q in (
+                    p(x_tip, y),
+                    p(x_neck, y - head_half),
+                    p(x_neck, y + head_half),
+                )
+            ],
             color=Color(spec["head"], glow=glow),
             border_color=Color(spec["head"], glow=glow),
             border_width=stroke(1.0),
@@ -391,8 +418,9 @@ def laser_neural_net(scene=None) -> Group:
         # A bead where each fan leaves its source ring and where it lands.
         for ya in ys_a:
             spots.append(
-                _hotspot(xa + NODE_R, ya, spec["start"],
-                         glow=HOTSPOT_GLOW * 0.6, scene=scene)
+                _hotspot(
+                    xa + NODE_R, ya, spec["start"], glow=HOTSPOT_GLOW * 0.6, scene=scene
+                )
             )
         for yb in ys_b:
             spots.append(_hotspot(xb - NODE_R, yb, spec["end"], scene=scene))
@@ -421,9 +449,7 @@ REFERENCE = VideoSettings(resolution=(IMG_W, IMG_H), frames_per_second=1)
 #: the gaps between them, and the reference keeps those gaps black.  Narrowing
 #: the tail and paying for it with ``strength`` gives the reference's look: a
 #: hot, local halo over a dark field.
-TIGHT_BLOOM = partial(
-    bloom_filter, glow_spread=0.015, tail_weight=0.15, strength=60
-)
+TIGHT_BLOOM = partial(bloom_filter, glow_spread=0.015, tail_weight=0.15, strength=60)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,10 @@ dependencies = [
     "svgelements>=1.0.0",
     "torch>=2.0.0",
     "torchvision>=0.15.0",
+    # Render progress bar (algan.render_loop). Already arrives transitively via
+    # manim and moviepy's proglog; named here because Algan imports it directly.
+    # 4.51 is where tqdm.contrib.logging.logging_redirect_tqdm appeared.
+    "tqdm>=4.51.0",
     # glTF/glB/OBJ/PLY parsing for ThreeDModelMob (algan.mobs.three_d_models).
     # Unlike the FBX path this needs no native library, so it is a core
     # dependency rather than an extra.

--- a/uv.lock
+++ b/uv.lock
@@ -71,6 +71,7 @@ dependencies = [
     { name = "taichi" },
     { name = "torch" },
     { name = "torchvision" },
+    { name = "tqdm" },
     { name = "trimesh", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "trimesh", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
@@ -155,6 +156,7 @@ requires-dist = [
     { name = "torch", specifier = ">=2.0.0" },
     { name = "torchaudio", marker = "extra == 'audio'", specifier = ">=2.0.0" },
     { name = "torchvision", specifier = ">=0.15.0" },
+    { name = "tqdm", specifier = ">=4.51.0" },
     { name = "transformers", marker = "extra == 'audio'", specifier = ">=4.30.0" },
     { name = "trimesh", specifier = ">=4.0.0" },
     { name = "types-decorator", marker = "extra == 'dev'", specifier = ">=5.1.8.20250121" },


### PR DESCRIPTION
## Summary
Replaces the custom in-place progress reporting with `tqdm`, providing better UX on terminals (ETA estimates) while maintaining readable output in non-TTY environments (CI, pytest, render daemon).

## Changes
- **Progress reporting refactored from imperative to context manager**: `_emit_render_progress()` and `_finish_render_progress()` replaced with `_render_progress()` context manager that yields a callable invoked once per frame
- **TTY detection preserved**: On terminals, uses `tqdm` with global averaging (smoothing=0) to avoid EWMA swings during early batches when users read estimates; on non-TTY, falls back to periodic log lines (at most 10 per render)
- **Logging integration**: Routes console logging through `tqdm.write()` during bar lifetime so warnings/perf messages print above the bar instead of smearing it
- **Call site simplified**: `render_to_video()` now uses the context manager directly, eliminating frame counter tracking
- **Dependency added**: `tqdm>=4.51.0` (already transitive via manim/moviepy; now explicit since Algan imports it directly)

## Implementation Details
- The context manager settles whether to report at all on entry (not per-frame), allowing log level changes mid-render without conjuring/retiring a bar
- `tqdm` configuration uses `smoothing=0` (global average) instead of the default EWMA (0.3), which is more appropriate for batch-oriented rendering where frames arrive in bursts
- Non-TTY path uses a closure to track frame count and emit logs at 10% intervals, matching the old behavior
- `logging_redirect_tqdm()` swaps only stdout/stderr handlers, leaving file handlers and non-StreamHandler types (e.g., Manim's rich handler) untouched

https://claude.ai/code/session_0156B21RPX9Dm5u2LHDJQv9Q