### PR TITLE
Add typed accessors for environment variables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,8 +174,10 @@ Structural batch rewrites (e.g. `become`'s batch expansion) go through `_setattr
 - Keep Taichi debug mode off (`ALGAN_TI_DEBUG=1` opts in); debug mode makes the megakernels ~11x slower.
 - In kernels, use `ti.static(bool(x))` rather than `is not None` for template gates.
 
-### Initialization-only settings
-These are read while Torch/Taichi initialize, so they must be set **before** `import algan` and have no runtime Python object: `ALGAN_ANIMATION_DEVICE`, `ALGAN_RENDER_DEVICE`, `ALGAN_HOME`, `ALGAN_CACHE_DIR`, `TI_OFFLINE_CACHE_FILE_PATH`, `ALGAN_SOFT_SHADOW_SAMPLES`, `ALGAN_HDR_BUFFER_F16`. `SETTINGS.computing.set(render_device=...)` raises with that instruction rather than a generic "unknown setting".
+### Environment variables
+Every `ALGAN_` variable the package honors is declared in `algan/environment.py`, and every read goes through that module's `env_flag` / `env_int` / `env_float` / `env_str` / `env_is_set` accessors, which **reject an undeclared name** — that is what lets `import algan` tell a real option from a misspelled one (it warns about `ALGAN_` variables it does not know). Adding a knob is therefore two steps: put the name in the right tuple in `algan/environment.py`, then read it with an accessor at the point of use, where the default lives next to the comment explaining it. Values parse leniently: an unusable one warns and falls back to the caller's default rather than aborting the render. `tests/unit_tests/test_environment.py` enforces the rule that nothing in the package reaches an `ALGAN_` variable through `os` directly.
+
+**Initialization-only settings** are read while Torch/Taichi initialize, so they must be set **before** `import algan` and have no runtime Python object: `ALGAN_ANIMATION_DEVICE`, `ALGAN_RENDER_DEVICE`, `ALGAN_HOME`, `ALGAN_CACHE_DIR`, `TI_OFFLINE_CACHE_FILE_PATH`, `ALGAN_SOFT_SHADOW_SAMPLES`, `ALGAN_HDR_BUFFER_F16` and the Taichi/warm-start trio — `_STARTUP_VARIABLES` in `algan/environment.py` is the list of record, and the daemon derives its `STARTUP_ENV` from it. `SETTINGS.computing.set(render_device=...)` raises with that instruction rather than a generic "unknown setting".
 
 ### Performance discipline
 - **`DESIGN_optimization_targets.md` is the plan of record for render performance.** It opens with a status table, how to reproduce the reference profile, and what to verify. Read it before starting (or resuming) optimization work, and update it when something lands.

--- a/algan/animation_timeline/timeline.py
+++ b/algan/animation_timeline/timeline.py
@@ -7,6 +7,7 @@ import math
 import numpy as np
 import torch
 
+from algan.environment import env_str
 from algan.utils.tensor_utils import cast_to_tensor
 
 #: Torch -> numpy dtypes for :func:`_sparsely_written_zeros`. Only the dtypes an
@@ -102,9 +103,7 @@ def _opt_disabled(name):
     """
     global _OPT_DISABLED
     if _OPT_DISABLED is None:
-        import os
-
-        _OPT_DISABLED = frozenset(os.environ.get("ALGAN_OPT_DISABLE", "").split(","))
+        _OPT_DISABLED = frozenset(env_str("ALGAN_OPT_DISABLE", "").split(","))
     return name in _OPT_DISABLED
 
 

--- a/algan/daemon.py
+++ b/algan/daemon.py
@@ -89,15 +89,18 @@ import traceback
 # and neither must the scripts it executes. Set before algan is imported,
 # because the handoff hook fires during that import -- without this, launching
 # a second daemon while one is live would make the second serve itself to the
-# first.
+# first. Written through os directly for the same reason: importing
+# algan.environment to reach its accessors would import algan, which is the
+# very import this has to precede.
 os.environ["ALGAN_DAEMON_CHILD"] = "1"
 
 import algan  # noqa: E402, F401  (the whole point: pay the import once, up front)
 from algan import SceneManager
 from algan import daemon_client as _dc
+from algan.environment import env_int
 from algan.settings import SETTINGS
 
-DEFAULT_PORT = int(os.environ.get("ALGAN_DAEMON_PORT", "46711"))
+DEFAULT_PORT = env_int("ALGAN_DAEMON_PORT", 46711)
 _ALGAN_DIR = os.path.dirname(os.path.abspath(algan.__file__))
 
 # The daemon's own console, captured before any run can redirect sys.stdout to

--- a/algan/daemon_client.py
+++ b/algan/daemon_client.py
@@ -27,9 +27,11 @@ locally could duplicate them. That case reports an error and exits non-zero.
 ``ALGAN_DAEMON_CHILD=1`` is set by the daemon around its own execution of a
 script, and is what stops the handoff from recursing.
 
-Only the standard library is imported here, and the module must stay that way:
-it runs before ``algan/__init__.py`` has imported torch, and its whole value is
-that a client process never pays for what it does not use.
+Nothing heavier than the standard library and :mod:`algan.environment` (which
+is itself stdlib-only, and already imported by the time this module loads) may
+be imported here, and the module must stay that way: it runs before
+``algan/__init__.py`` has imported torch, and its whole value is that a client
+process never pays for what it does not use.
 """
 
 from __future__ import annotations
@@ -41,13 +43,20 @@ import socket
 import struct
 import sys
 
+from algan.environment import (
+    env_flag,
+    env_float,
+    env_str,
+    startup_environment_variables,
+)
+
 #: Bumped when the wire format changes. A client and daemon that disagree
 #: refuse each other rather than misparse, and the client falls back.
 PROTOCOL_VERSION = 1
 
 #: Seconds to wait for the daemon's TCP accept. Short on purpose: a daemon
 #: that cannot answer promptly is not worth blocking a cold run for.
-CONNECT_TIMEOUT = float(os.environ.get("ALGAN_DAEMON_TIMEOUT", "2.0"))
+CONNECT_TIMEOUT = env_float("ALGAN_DAEMON_TIMEOUT", 2.0)
 
 # Frame kinds on the daemon -> client stream. Each frame is one kind byte, a
 # 4-byte big-endian length, then that many payload bytes.
@@ -61,21 +70,10 @@ FRAME_EXIT = b"X"  # payload is a 4-byte big-endian signed exit code
 #: Environment variables consumed while Torch and Taichi initialise. The daemon
 #: baked its values at launch and cannot change them, so a client whose values
 #: differ is refused and runs cold rather than silently rendering on the wrong
-#: device or against the wrong cache. Keep in step with
-#: ``algan/settings/_startup.py`` and the "Initialization-only settings"
-#: section of ``CLAUDE.md``.
-STARTUP_ENV = (
-    "ALGAN_ANIMATION_DEVICE",
-    "ALGAN_RENDER_DEVICE",
-    "ALGAN_HOME",
-    "ALGAN_CACHE_DIR",
-    "TI_OFFLINE_CACHE_FILE_PATH",
-    "ALGAN_SOFT_SHADOW_SAMPLES",
-    "ALGAN_HDR_BUFFER_F16",
-    "ALGAN_TI_DEBUG",
-    "ALGAN_TAICHI_WARMSTART",
-    "ALGAN_TAICHI_FAST_LAUNCH",
-)
+#: device or against the wrong cache. Declared in :mod:`algan.environment`
+#: alongside every other variable Algan honors; see also the
+#: "Initialization-only settings" section of ``CLAUDE.md``.
+STARTUP_ENV = startup_environment_variables()
 
 
 class DaemonUnavailable(Exception):
@@ -96,9 +94,7 @@ def algan_home():
     Duplicated from :mod:`algan.settings._startup` rather than imported: that
     module imports torch, which is exactly what a client is avoiding.
     """
-    home = os.environ.get("ALGAN_HOME") or os.path.join(
-        os.path.expanduser("~"), ".algan"
-    )
+    home = env_str("ALGAN_HOME") or os.path.join(os.path.expanduser("~"), ".algan")
     return os.path.expanduser(home)
 
 
@@ -109,7 +105,7 @@ def state_path():
 
 def startup_env():
     """The subset of the environment that the daemon bakes in at launch."""
-    return {name: os.environ.get(name, "") for name in STARTUP_ENV}
+    return {name: env_str(name, "") for name in STARTUP_ENV}
 
 
 def describe_env_mismatch(client_env, daemon_env):
@@ -194,9 +190,9 @@ def should_try(main_module=None):
     silently reroute an unrelated process into a shared daemon, which is much
     worse than a false negative costing one cold start.
     """
-    if os.environ.get("ALGAN_DAEMON_CHILD") == "1":
+    if env_flag("ALGAN_DAEMON_CHILD", False):
         return False
-    if os.environ.get("ALGAN_USE_DAEMON", "1") == "0":
+    if not env_flag("ALGAN_USE_DAEMON", True):
         return False
     if sys.flags.interactive:
         return False

--- a/algan/environment.py
+++ b/algan/environment.py
@@ -1,8 +1,22 @@
-"""Validation for Algan's process environment.
+"""Declaration, validation and typed access for Algan's process environment.
 
-Environment variables are deliberately listed in one place so misspelled
-``ALGAN_`` options do not fail silently. Keep this registry in sync whenever a
-new environment-controlled option is added to the package.
+Every environment variable Algan honors is declared in this module, and every
+read of one goes through the ``env_*`` accessors below, which reject a name
+that is not declared. That is what keeps the registry honest: the list is not
+a copy of what the code reads, it is what the code reads *through*, so a knob
+added without a declaration raises on its first read instead of quietly
+becoming a variable users can misspell without warning.
+
+Adding a variable is therefore one edit -- put its name in the right tuple
+below -- and reading it is ``env_flag("ALGAN_...", default)`` or one of its
+siblings at the point of use, where the default belongs next to the comment
+explaining it. ``tests/unit_tests/test_environment.py`` enforces the one rule
+that keeps the invariant intact: nothing in the package may reach an
+``ALGAN_`` variable through :mod:`os` directly.
+
+Values are parsed leniently and never fatally: an unusable value warns and
+falls back to the caller's default, because a mistyped tuning knob should not
+abort a render.
 """
 
 from __future__ import annotations
@@ -11,119 +25,249 @@ import os
 import warnings
 from collections.abc import Mapping
 
-from algan.errors import AlganWarning
+from algan.errors import AlganConfigurationError, AlganWarning
 
-ALGAN_ENVIRONMENT_VARIABLES = frozenset(
-    {
-        "ALGAN_AA_DUMP",
-        "ALGAN_ADV_OPT",
-        "ALGAN_ANALYTIC_AA",
-        "ALGAN_ANALYTIC_AA_BEZ",
-        "ALGAN_ANALYTIC_AA_BEZ_MIN_HALF_WIDTH",
-        "ALGAN_ANALYTIC_AA_BEZ_WEDGE",
-        "ALGAN_ANALYTIC_AA_CHORD_TOLERANCE",
-        "ALGAN_ANALYTIC_AA_EXACT",
-        "ALGAN_ANALYTIC_AA_SEAM",
-        "ALGAN_ANALYTIC_AA_SECONDARY",
-        "ALGAN_ANALYTIC_AA_SECONDARY_MIN_ENERGY",
-        "ALGAN_ANALYTIC_AA_RUN",
-        "ALGAN_ANALYTIC_AA_RUN_RULE",
-        "ALGAN_ANALYTIC_AA_SLIVER",
-        "ALGAN_ANALYTIC_AA_TRI",
-        "ALGAN_ANIMATION_DEVICE",
-        "ALGAN_BATCH_BEZIER_PREP",
-        "ALGAN_BATCH_SURFACE_PREP",
-        "ALGAN_BLOOM_FFT_SMOOTH",
-        "ALGAN_BVH_ARITY",
-        "ALGAN_BVH_BLOCK_F16",
-        "ALGAN_BVH_BUILD",
-        "ALGAN_BVH_DEFER",
-        "ALGAN_BVH_REFIT",
-        "ALGAN_CACHE_DIR",
-        "ALGAN_DAEMON_CHILD",
-        "ALGAN_DAEMON_PORT",
-        "ALGAN_DAEMON_TIMEOUT",
-        "ALGAN_FRAG_PID_GATE",
-        "ALGAN_GLOSSY_INTERLEAVE",
-        "ALGAN_GLOSSY_REFLECTION",
-        "ALGAN_GPU_MAX_REG",
-        "ALGAN_HDR_BUFFER_F16",
-        "ALGAN_HOME",
-        "ALGAN_HYBRID_RASTER",
-        "ALGAN_INPLACE_AA",
-        "ALGAN_KBUF",
-        "ALGAN_LOG_LEVEL",
-        "ALGAN_LOG_TAICHI_COMPILES",
-        "ALGAN_MANIM_SVG_CACHE_MB",
-        "ALGAN_MAX_SHADOW_LIGHTS",
-        "ALGAN_MERGE_DEDUP_TIME",
-        "ALGAN_MERGE_GPU_PEAK_FACTOR",
-        "ALGAN_MERGE_ON_GPU",
-        "ALGAN_MERGE_TRACK_PEAK",
-        "ALGAN_OPAQUE_BVH_SKIP_DEAD",
-        "ALGAN_OPT_DISABLE",
-        "ALGAN_OPT_LEVEL",
-        "ALGAN_PN_CRITERION_KERNEL",
-        "ALGAN_PN_OBB",
-        "ALGAN_POST_PROCESS_TONEMAP",
-        "ALGAN_POST_TONEMAP_KERNEL",
-        "ALGAN_PREFETCH_BATCHES",
-        "ALGAN_PREFETCH_MERGE",
-        "ALGAN_PROFILE_CPROFILE",
-        "ALGAN_PROFILE_NVPROF",
-        "ALGAN_PROFILE_RUNS",
-        "ALGAN_PROFILE_TELEMETRY",
-        "ALGAN_PROGRESS",
-        "ALGAN_PROJECT_GPU_PEAK_FACTOR",
-        "ALGAN_PROJECT_ON_GPU",
-        "ALGAN_PROMOTE_CONSTANTS",
-        "ALGAN_RASTER_BEZ_PRECOMPUTE",
-        "ALGAN_RASTER_COVERED_SHADE",
-        "ALGAN_RASTER_EMPTY_SKIP",
-        "ALGAN_RASTER_PAIR_FLAGS",
-        "ALGAN_RASTER_SPARSE_COVERAGE",
-        "ALGAN_RASTER_SS",
-        "ALGAN_RASTER_STRADDLE_CLIP",
-        "ALGAN_RASTER_TRI_PRECOMPUTE",
-        "ALGAN_RENDER_DEVICE",
-        "ALGAN_REUSE_FETCHED_BATCH",
-        "ALGAN_SHADOW_ANYHIT",
-        "ALGAN_SLICE_ACROSS_SPAWNS",
-        "ALGAN_SOFT_SHADOW_SAMPLES",
-        "ALGAN_SPARSE_DISCOVERY_SAFETY",
-        "ALGAN_SPLIT_TIME_WEIGHT",
-        "ALGAN_STBVH_LEAF_SIZE",
-        "ALGAN_STBVH_TIGHTNESS",
-        "ALGAN_TAICHI_COMPILE_LOG",
-        "ALGAN_TAICHI_FAST_LAUNCH",
-        "ALGAN_TAICHI_FAST_LAUNCH_VERIFY",
-        "ALGAN_TAICHI_WARMSTART",
-        "ALGAN_TAICHI_WARMSTART_VERIFY",
-        "ALGAN_TI_DEBUG",
-        "ALGAN_TI_KERNEL_PROFILER",
-        "ALGAN_UNDER_NVPROF",
-        "ALGAN_UNSUPPORTED_FEATURE_POLICY",
-        "ALGAN_USE_DAEMON",
-        "ALGAN_WAVEFRONT_INITIAL_POOL_RATIO",
-        "ALGAN_WAVEFRONT_SPLIT",
-        "ALGAN_WAVEFRONT_TILE",
-        "ALGAN_WAVEFRONT_TILE_AUTO",
-        "ALGAN_WAVEFRONT_TILE_MAX",
-        "ALGAN_WAVEFRONT_TILE_MIN",
-        "ALGAN_WAVEFRONT_TILE_SAFETY",
-        "ALGAN_WF_COMPACT_ACTIVE_ONLY",
-        "ALGAN_WF_GEN_FUSED",
-        "ALGAN_WF_GEN_FUSED_GAIN",
-        "ALGAN_WF_GEN_FUSED_MIN_WIN",
-        "ALGAN_WF_MEM_TRIM",
-        "ALGAN_WF_NEAR_FIRST",
-        "ALGAN_WF_OPAQUE_CLOSEST",
-        "ALGAN_WF_OPAQUE_PREPASS",
-        "ALGAN_WF_REVALIDATE_PENDING",
-        "ALGAN_WF_SKIP_UNLIT_NORMAL",
-        "ALGAN_WF_TEXTURED_FEATURES",
-    }
+#: Variables consumed while Torch and Taichi initialise. They must be set
+#: before ``import algan`` and have no runtime Python setting; the render
+#: daemon bakes their values at launch and refuses a client whose values
+#: differ (see :data:`algan.daemon_client.STARTUP_ENV`, derived from this
+#: tuple). Order is the order mismatches are reported in.
+_STARTUP_VARIABLES = (
+    "ALGAN_ANIMATION_DEVICE",
+    "ALGAN_RENDER_DEVICE",
+    "ALGAN_HOME",
+    "ALGAN_CACHE_DIR",
+    "TI_OFFLINE_CACHE_FILE_PATH",
+    "ALGAN_SOFT_SHADOW_SAMPLES",
+    "ALGAN_HDR_BUFFER_F16",
+    "ALGAN_TI_DEBUG",
+    "ALGAN_TAICHI_WARMSTART",
+    "ALGAN_TAICHI_FAST_LAUNCH",
 )
+
+#: Variables read by the test and benchmark harnesses rather than by the
+#: package. Declared so that a contributor who exports one -- as
+#: ``CLAUDE.md``, ``tests/README.md`` and the contributing docs tell them to
+#: -- does not get told it is unknown on every import.
+_HARNESS_VARIABLES = (
+    "ALGAN_RUN_DOC_RENDERS",
+    "ALGAN_RUN_FULL_RENDERS",
+    "ALGAN_UPDATE_FAST_BASELINE",
+    "ALGAN_UPDATE_FULL_RENDER_BASELINES",
+)
+
+#: Everything else: read at import of the module that owns the knob, or live
+#: at the point of use. Alphabetical.
+_RUNTIME_VARIABLES = (
+    "ALGAN_AA_DUMP",
+    "ALGAN_ADV_OPT",
+    "ALGAN_ANALYTIC_AA",
+    "ALGAN_ANALYTIC_AA_BEZ",
+    "ALGAN_ANALYTIC_AA_BEZ_MIN_HALF_WIDTH",
+    "ALGAN_ANALYTIC_AA_BEZ_WEDGE",
+    "ALGAN_ANALYTIC_AA_CHORD_TOLERANCE",
+    "ALGAN_ANALYTIC_AA_EXACT",
+    "ALGAN_ANALYTIC_AA_SEAM",
+    "ALGAN_ANALYTIC_AA_SECONDARY",
+    "ALGAN_ANALYTIC_AA_SECONDARY_MIN_ENERGY",
+    "ALGAN_ANALYTIC_AA_RUN",
+    "ALGAN_ANALYTIC_AA_RUN_RULE",
+    "ALGAN_ANALYTIC_AA_SLIVER",
+    "ALGAN_ANALYTIC_AA_TRI",
+    "ALGAN_BATCH_BEZIER_PREP",
+    "ALGAN_BATCH_SURFACE_PREP",
+    "ALGAN_BLOOM_FFT_SMOOTH",
+    "ALGAN_BVH_ARITY",
+    "ALGAN_BVH_BLOCK_F16",
+    "ALGAN_BVH_BUILD",
+    "ALGAN_BVH_DEFER",
+    "ALGAN_BVH_REFIT",
+    "ALGAN_DAEMON_CHILD",
+    "ALGAN_DAEMON_PORT",
+    "ALGAN_DAEMON_TIMEOUT",
+    "ALGAN_FRAG_PID_GATE",
+    "ALGAN_GLOSSY_INTERLEAVE",
+    "ALGAN_GLOSSY_REFLECTION",
+    "ALGAN_GPU_MAX_REG",
+    "ALGAN_HYBRID_RASTER",
+    "ALGAN_INPLACE_AA",
+    "ALGAN_KBUF",
+    "ALGAN_LOG_LEVEL",
+    "ALGAN_LOG_TAICHI_COMPILES",
+    "ALGAN_MANIM_SVG_CACHE_MB",
+    "ALGAN_MAX_SHADOW_LIGHTS",
+    "ALGAN_MERGE_DEDUP_TIME",
+    "ALGAN_MERGE_GPU_PEAK_FACTOR",
+    "ALGAN_MERGE_ON_GPU",
+    "ALGAN_MERGE_TRACK_PEAK",
+    "ALGAN_OPAQUE_BVH_SKIP_DEAD",
+    "ALGAN_OPT_DISABLE",
+    "ALGAN_OPT_LEVEL",
+    "ALGAN_PN_CRITERION_KERNEL",
+    "ALGAN_PN_OBB",
+    "ALGAN_POST_PROCESS_TONEMAP",
+    "ALGAN_POST_TONEMAP_KERNEL",
+    "ALGAN_PREFETCH_BATCHES",
+    "ALGAN_PREFETCH_MERGE",
+    "ALGAN_PROFILE_CPROFILE",
+    "ALGAN_PROFILE_NVPROF",
+    "ALGAN_PROFILE_RUNS",
+    "ALGAN_PROFILE_TELEMETRY",
+    "ALGAN_PROGRESS",
+    "ALGAN_PROJECT_GPU_PEAK_FACTOR",
+    "ALGAN_PROJECT_ON_GPU",
+    "ALGAN_PROMOTE_CONSTANTS",
+    "ALGAN_RASTER_BEZ_PRECOMPUTE",
+    "ALGAN_RASTER_COVERED_SHADE",
+    "ALGAN_RASTER_EMPTY_SKIP",
+    "ALGAN_RASTER_PAIR_FLAGS",
+    "ALGAN_RASTER_SPARSE_COVERAGE",
+    "ALGAN_RASTER_SS",
+    "ALGAN_RASTER_STRADDLE_CLIP",
+    "ALGAN_RASTER_TRI_PRECOMPUTE",
+    "ALGAN_REUSE_FETCHED_BATCH",
+    "ALGAN_SHADOW_ANYHIT",
+    "ALGAN_SLICE_ACROSS_SPAWNS",
+    "ALGAN_SPARSE_DISCOVERY_SAFETY",
+    "ALGAN_SPLIT_TIME_WEIGHT",
+    "ALGAN_STBVH_LEAF_SIZE",
+    "ALGAN_STBVH_TIGHTNESS",
+    "ALGAN_TAICHI_COMPILE_LOG",
+    "ALGAN_TAICHI_FAST_LAUNCH_VERIFY",
+    "ALGAN_TAICHI_WARMSTART_VERIFY",
+    "ALGAN_TI_KERNEL_PROFILER",
+    "ALGAN_UNDER_NVPROF",
+    "ALGAN_UNSUPPORTED_FEATURE_POLICY",
+    "ALGAN_USE_DAEMON",
+    "ALGAN_WAVEFRONT_INITIAL_POOL_RATIO",
+    "ALGAN_WAVEFRONT_SPLIT",
+    "ALGAN_WAVEFRONT_TILE",
+    "ALGAN_WAVEFRONT_TILE_AUTO",
+    "ALGAN_WAVEFRONT_TILE_MAX",
+    "ALGAN_WAVEFRONT_TILE_MIN",
+    "ALGAN_WAVEFRONT_TILE_SAFETY",
+    "ALGAN_WF_COMPACT_ACTIVE_ONLY",
+    "ALGAN_WF_GEN_FUSED",
+    "ALGAN_WF_GEN_FUSED_GAIN",
+    "ALGAN_WF_GEN_FUSED_MIN_WIN",
+    "ALGAN_WF_MEM_TRIM",
+    "ALGAN_WF_NEAR_FIRST",
+    "ALGAN_WF_OPAQUE_CLOSEST",
+    "ALGAN_WF_OPAQUE_PREPASS",
+    "ALGAN_WF_REVALIDATE_PENDING",
+    "ALGAN_WF_SKIP_UNLIT_NORMAL",
+    "ALGAN_WF_TEXTURED_FEATURES",
+)
+
+#: Every declared name, including the one variable Algan honors that is not
+#: its own (Taichi's ``TI_OFFLINE_CACHE_FILE_PATH``).
+_DECLARED = frozenset(_STARTUP_VARIABLES + _HARNESS_VARIABLES + _RUNTIME_VARIABLES)
+
+#: The ``ALGAN_`` variables this version accepts. Anything else in the
+#: environment with that prefix is a typo or a leftover from an older
+#: version, and is reported at import.
+ALGAN_ENVIRONMENT_VARIABLES = frozenset(
+    name for name in _DECLARED if name.startswith("ALGAN_")
+)
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_FALSE_VALUES = frozenset({"0", "false", "no", "off"})
+
+
+def startup_environment_variables() -> tuple[str, ...]:
+    """The variables consumed while Torch and Taichi initialise, in report order."""
+    return _STARTUP_VARIABLES
+
+
+def _require_declared(name: str) -> None:
+    if name not in _DECLARED:
+        raise AlganConfigurationError(
+            f"{name} is not a declared Algan environment variable. This is a "
+            "bug in Algan, not in your environment: every variable the package "
+            "reads must be listed in algan/environment.py, which is what lets "
+            "Algan tell a real option from a misspelled one."
+        )
+
+
+def _raw(name: str) -> str | None:
+    _require_declared(name)
+    return os.environ.get(name)
+
+
+def _warn_unusable(name: str, raw: str, expected: str, default) -> None:
+    warnings.warn(
+        f"{name}={raw!r} is not {expected}; using the default {default!r}.",
+        AlganWarning,
+        stacklevel=3,
+    )
+
+
+def env_is_set(name: str) -> bool:
+    """Whether ``name`` is present in the environment, whatever its value."""
+    _require_declared(name)
+    return name in os.environ
+
+
+def env_str(name: str, default: str | None = "") -> str | None:
+    """The raw value of ``name``, or ``default`` when it is unset.
+
+    Deliberately unstripped: callers that treat surrounding whitespace as
+    significant (a path, a mode word) decide that themselves.
+    """
+    raw = _raw(name)
+    return default if raw is None else raw
+
+
+def env_flag(name: str, default: bool) -> bool:
+    """``name`` parsed as a boolean, or ``default`` when unset or unusable.
+
+    ``1``/``true``/``yes``/``on`` and ``0``/``false``/``no``/``off`` are all
+    accepted, case- and whitespace-insensitively. An empty value counts as
+    unset, so ``ALGAN_X=`` leaves the default in place.
+    """
+    raw = _raw(name)
+    if raw is None:
+        return default
+    value = raw.strip().lower()
+    if not value:
+        return default
+    if value in _TRUE_VALUES:
+        return True
+    if value in _FALSE_VALUES:
+        return False
+    _warn_unusable(name, raw, "a boolean (1/0, true/false, yes/no, on/off)", default)
+    return default
+
+
+def env_int(name: str, default: int) -> int:
+    """``name`` parsed as an integer, or ``default`` when unset or unusable."""
+    raw = _raw(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw.strip())
+    except ValueError:
+        _warn_unusable(name, raw, "an integer", default)
+        return default
+
+
+def env_float(name: str, default: float) -> float:
+    """``name`` parsed as a float, or ``default`` when unset or unusable."""
+    raw = _raw(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw.strip())
+    except ValueError:
+        _warn_unusable(name, raw, "a number", default)
+        return default
+
+
+def env_overrides(**values: str) -> dict[str, str]:
+    """Declared ``name=value`` pairs, for building a child process's environment."""
+    for name in values:
+        _require_declared(name)
+    return dict(values)
 
 
 def unknown_algan_environment_variables(
@@ -159,6 +303,13 @@ def warn_for_unknown_algan_environment_variables(
 
 __all__ = [
     "ALGAN_ENVIRONMENT_VARIABLES",
+    "env_flag",
+    "env_float",
+    "env_int",
+    "env_is_set",
+    "env_overrides",
+    "env_str",
+    "startup_environment_variables",
     "unknown_algan_environment_variables",
     "warn_for_unknown_algan_environment_variables",
 ]

--- a/algan/logging/logger.py
+++ b/algan/logging/logger.py
@@ -38,6 +38,8 @@ import logging
 import os
 import sys
 
+from algan.environment import env_str
+
 #: Renderer budget/recovery diagnostics: below ``INFO`` so they stay off by
 #: default, above ``DEBUG`` so turning them on does not also enable every other
 #: debug message in the package.
@@ -76,7 +78,7 @@ if not logger.handlers:
     _handler = _LiveStderrHandler()
     _handler.setFormatter(logging.Formatter("%(message)s"))
     logger.addHandler(_handler)
-    logger.setLevel(os.environ.get("ALGAN_LOG_LEVEL", "INFO").upper())
+    logger.setLevel(env_str("ALGAN_LOG_LEVEL", "INFO").upper())
     # Don't double-print through the root logger if the application configured it.
     logger.propagate = False
 
@@ -273,7 +275,7 @@ def set_log_level(level):
 # Unlike ALGAN_LOG_LEVEL this is not read at import for any technical reason --
 # set_progress_style works at any time -- it is read here only so the variable
 # behaves like every other ALGAN_ one.
-_ENV_PROGRESS = os.environ.get("ALGAN_PROGRESS")
+_ENV_PROGRESS = env_str("ALGAN_PROGRESS", None)
 if _ENV_PROGRESS:
     try:
         set_progress_style(_ENV_PROGRESS)

--- a/algan/render_loop.py
+++ b/algan/render_loop.py
@@ -32,6 +32,7 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 
 import algan.rendering.raytracing.settings as rt_settings_module
 from algan.animation_timeline.animation_contexts import Off
+from algan.environment import env_flag
 from algan.errors import _user_stacklevel
 from algan.logging.logger import PERF, get_logger, resolve_progress_style
 from algan.rendering.memory_model import (
@@ -522,7 +523,7 @@ class RenderLoopMixin:
         correct, and re-fetching costs a full rematerialization per batch.
         Set ``ALGAN_SLICE_ACROSS_SPAWNS=0`` to rematerialize instead.
         """
-        return os.environ.get("ALGAN_SLICE_ACROSS_SPAWNS", "1") != "0"
+        return env_flag("ALGAN_SLICE_ACROSS_SPAWNS", True)
 
     def _fetched_window_has_stable_actor_set(self, actors, start_ind, end_ind):
         """Whether no renderable actor spawns inside a fetched frame window.
@@ -553,7 +554,7 @@ class RenderLoopMixin:
         keeps the candidate's shader/projection mutations isolated from the
         original CPU batch, which is retained for later probes.
         """
-        if os.environ.get("ALGAN_REUSE_FETCHED_BATCH", "1") == "0":
+        if not env_flag("ALGAN_REUSE_FETCHED_BATCH", True):
             return False
         if total_frames <= 1 or not primitive_batch:
             return False
@@ -1494,7 +1495,7 @@ class RenderLoopMixin:
         # Mirror the tracer's anti-aliasing strategy (render_batch_raytraced):
         # default super-sampled buffer averaged down in post-processing;
         # ALGAN_INPLACE_AA keeps the buffer at output resolution.
-        inplace_aa = os.getenv("ALGAN_INPLACE_AA", "0") != "0"
+        inplace_aa = env_flag("ALGAN_INPLACE_AA", False)
         if inplace_aa:
             width = self.num_pixels_screen_width
             height = self.num_pixels_screen_height
@@ -1595,7 +1596,7 @@ class RenderLoopMixin:
         vertex-color path, and computed normals. Set ALGAN_BATCH_SURFACE_PREP=0
         to disable batching (A/B against the per-surface path).
         """
-        if os.environ.get("ALGAN_BATCH_SURFACE_PREP", "1") == "0":
+        if not env_flag("ALGAN_BATCH_SURFACE_PREP", True):
             return False
         from algan.mobs.surfaces.surface import Surface
 
@@ -1625,7 +1626,7 @@ class RenderLoopMixin:
         Set ALGAN_BATCH_BEZIER_PREP=0 to disable (A/B against the per-actor
         path).
         """
-        if os.environ.get("ALGAN_BATCH_BEZIER_PREP", "1") == "0":
+        if not env_flag("ALGAN_BATCH_BEZIER_PREP", True):
             return False
         from algan.mobs.bezier_circuit import BezierCircuitCubic
 
@@ -2298,7 +2299,7 @@ class RenderLoopMixin:
             # share no mutable state. All Taichi work stays on this thread.
             # Set ALGAN_PREFETCH_BATCHES=0 to fall back to serial (also
             # reduces peak memory by one batch's tensors).
-            prefetch_enabled = os.environ.get("ALGAN_PREFETCH_BATCHES", "1") != "0"
+            prefetch_enabled = env_flag("ALGAN_PREFETCH_BATCHES", True)
             # inference_mode is thread-local; mirror the caller's mode in the
             # worker so prep-created tensors can be mutated in-place later by
             # the render thread (inference tensors may only be modified while
@@ -2328,7 +2329,7 @@ class RenderLoopMixin:
 
                     if (
                         batch[0]
-                        and os.environ.get("ALGAN_PREFETCH_MERGE", "1") != "0"
+                        and env_flag("ALGAN_PREFETCH_MERGE", True)
                         and not rt_settings.project_on_gpu_active()
                     ):
                         try:

--- a/algan/rendering/post_processing/bloom.py
+++ b/algan/rendering/post_processing/bloom.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import math
-import os
 
 import torch
 import torch.fft
 import torch.nn.functional as F
+
+from algan.environment import env_flag
 
 # Round the bloom blur's transform length up to a length cuFFT has a native
 # factorization for, instead of transforming at exactly ``L + K - 1``. That
@@ -32,7 +33,7 @@ _SMOOTH_FACTORS = (2, 3, 5, 7)
 
 def _fft_length(exact):
     """Transform length to use for a convolution needing ``exact`` samples."""
-    if os.environ.get("ALGAN_BLOOM_FFT_SMOOTH", "1") == "0":
+    if not env_flag("ALGAN_BLOOM_FFT_SMOOTH", True):
         return exact
 
     def smooth(n):

--- a/algan/rendering/raytracing/primitives.py
+++ b/algan/rendering/raytracing/primitives.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import warnings
 from typing import NamedTuple
 
@@ -8,6 +7,7 @@ import torch
 import torch.nn.functional as F
 
 from algan.constants.color import Color
+from algan.environment import env_float
 from algan.rendering.logical_pn import (
     evaluate_cubic_curve,
     evaluate_logical_pn,
@@ -181,7 +181,7 @@ class RayTracedTrianglePrimitive(TrianglePrimitive):
         "shader_param_values",
     )
 
-    stbvh_tightness = float(os.environ.get("ALGAN_STBVH_TIGHTNESS", "1.0"))
+    stbvh_tightness = env_float("ALGAN_STBVH_TIGHTNESS", 1.0)
 
     # Renderer-internal transport channels, shared with
     # ``RayTracedBezierCircuitPrimitive``. ``reflectivity`` stores material
@@ -1896,7 +1896,7 @@ class RayTracedBezierCircuitPrimitive(BezierCircuitPrimitive):
                     ]
                 setattr(self, name, value)
 
-    stbvh_tightness = float(os.environ.get("ALGAN_STBVH_TIGHTNESS", "1.0"))
+    stbvh_tightness = env_float("ALGAN_STBVH_TIGHTNESS", 1.0)
     max_samples_per_segment = 512
     _rt_projection_aa = 1.0
 

--- a/algan/rendering/raytracing/raster_pipeline.py
+++ b/algan/rendering/raytracing/raster_pipeline.py
@@ -16,10 +16,9 @@ write directly into an arena view.
 
 from __future__ import annotations
 
-import os
-
 import torch
 
+from algan.environment import env_str
 from algan.settings import SETTINGS
 
 rt_settings = SETTINGS.raytracing
@@ -61,7 +60,7 @@ LAST_AA_DUMP = {}
 
 def _aa_dump_request():
     """The requested (px, py, frame) from ``ALGAN_AA_DUMP``, or ``None``."""
-    spec = os.environ.get("ALGAN_AA_DUMP", "")
+    spec = env_str("ALGAN_AA_DUMP", "")
     if not spec:
         return None
     try:

--- a/algan/rendering/raytracing/raytrace_kernels_taichi.py
+++ b/algan/rendering/raytracing/raytrace_kernels_taichi.py
@@ -62,10 +62,10 @@ separate from cold data (what only confirmed hits touch):
 Coplanar-surface layer order is bezier circuits < triangles < PN patches,
 with each type's primitive index breaking ties within the type.
 """
-import os
 
 import taichi as ti
 
+from algan.environment import env_flag, env_int
 from algan.rendering.raytracing.stbvh import BLOCK_F16, BVH_ARITY, LEAF_SIZE
 from algan.rendering.raytracing.bezier_acceleration import (
     BEZIER_ACCEL_HEADER_SIZE,
@@ -94,7 +94,7 @@ init_taichi()
 # is identical -- the OBB conservatively bounds the patch -- and it removes the
 # ~98% of solver invocations whose ray pierces a patch's loose axis-aligned leaf
 # box but misses the (thin, often diagonal) patch itself.
-_PN_OBB_ON = os.environ.get("ALGAN_PN_OBB", "1") == "1"
+_PN_OBB_ON = env_flag("ALGAN_PN_OBB", True)
 
 # Sibling-block traversal stack. The walk descends into one intersected
 # child at a time and pushes the sibling group's *remaining* mask; a complete
@@ -173,7 +173,7 @@ PN_SEAM_DEPTH_EPSILON = 8e-3
 # per-scene tuning: small KBUF closes the traversal's depth window as soon as
 # the buffer fills (tighter pruning for low-depth-complexity scenes), large
 # KBUF re-traverses less on deep translucent stacks.
-KBUF = max(1, int(os.environ.get("ALGAN_KBUF", "4")))
+KBUF = max(1, env_int("ALGAN_KBUF", 4))
 
 # Kernel-argument annotation for STBVH sibling-block arrays (see
 # stbvh._build_blocks): entry [i, lane] holds one attribute of internal node

--- a/algan/rendering/raytracing/settings.py
+++ b/algan/rendering/raytracing/settings.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import os
 import warnings
 
+from algan.environment import env_flag, env_float, env_int, env_is_set, env_str
 from algan.errors import UnsupportedFeatureError, UnsupportedFeatureWarning
 from algan.rendering.raytracing.shading_taichi import _USER_PIPELINE_BASE
 from algan.settings._startup import _HDR_BUFFER_F16, _RENDER_DEVICE
@@ -18,7 +18,7 @@ SAMPLES_PER_PIXEL = 1
 # features. "error" is the safe public default; "warn" and "ignore" are
 # available for controlled migration and benchmarking.
 UNSUPPORTED_FEATURE_POLICY = (
-    os.environ.get("ALGAN_UNSUPPORTED_FEATURE_POLICY", "error").strip().lower()
+    env_str("ALGAN_UNSUPPORTED_FEATURE_POLICY", "error").strip().lower()
 )
 if UNSUPPORTED_FEATURE_POLICY not in {"error", "warn", "ignore"}:
     UNSUPPORTED_FEATURE_POLICY = "error"
@@ -54,7 +54,7 @@ TONEMAP_METHOD = "neutral"
 # that is identity for empty pixels (enabling the covered-pixel compaction).
 # Costs a float32 frame buffer (4x the uint8 one), so fewer frames per batch.
 # Env override for A/B and re-baselining.
-POST_PROCESS_TONEMAP = os.environ.get("ALGAN_POST_PROCESS_TONEMAP", "1") == "1"
+POST_PROCESS_TONEMAP = env_flag("ALGAN_POST_PROCESS_TONEMAP", True)
 
 # Strength of diffuse indirect bounces in the Monte Carlo renderer: 0 keeps
 # surfaces purely (vertex-shader) lit, > 0 scatters paths on diffuse hits
@@ -76,17 +76,17 @@ GATE_EMPTY_TRAVERSALS = True
 # Wavefront traversal rollouts. Changes to sibling revalidation and child
 # ordering are enabled by default after parity validation; the opaque paths
 # remain opt-in until their scene classification and shading gates are proven.
-WF_REVALIDATE_PENDING = os.environ.get("ALGAN_WF_REVALIDATE_PENDING", "0") == "1"
-WF_NEAR_FIRST = os.environ.get("ALGAN_WF_NEAR_FIRST", "0") == "1"
-WF_OPAQUE_CLOSEST = os.environ.get("ALGAN_WF_OPAQUE_CLOSEST", "0") == "1"
-WF_OPAQUE_PREPASS = os.environ.get("ALGAN_WF_OPAQUE_PREPASS", "0") == "1"
+WF_REVALIDATE_PENDING = env_flag("ALGAN_WF_REVALIDATE_PENDING", False)
+WF_NEAR_FIRST = env_flag("ALGAN_WF_NEAR_FIRST", False)
+WF_OPAQUE_CLOSEST = env_flag("ALGAN_WF_OPAQUE_CLOSEST", False)
+WF_OPAQUE_PREPASS = env_flag("ALGAN_WF_OPAQUE_PREPASS", False)
 
-INPLACE_AA = os.environ.get("ALGAN_INPLACE_AA", "0") == "1"
+INPLACE_AA = env_flag("ALGAN_INPLACE_AA", False)
 # Rays per wavefront screen tile. The wavefront holds per-ray state for every
 # ray it processes at once (~(18 + 6*KBUF) floats/ray); processing the chunk in
 # tiles of this many rays bounds that state so it fits at any resolution / chunk
 # length (a single HD frame is ~2M rays). ~2M rays * ~168 B ~= 350 MB of state.
-WAVEFRONT_TILE_RAYS = int(os.environ.get("ALGAN_WAVEFRONT_TILE", str(1 << 21)))
+WAVEFRONT_TILE_RAYS = env_int("ALGAN_WAVEFRONT_TILE", 1 << 21)
 # Adaptive tile sizing: size wavefront tiles from the render pool's *actual*
 # free bytes instead of the fixed WAVEFRONT_TILE_RAYS. The static ~2M-ray
 # default keeps tiles small enough for any GPU, but every tile pays a fixed
@@ -106,20 +106,20 @@ WAVEFRONT_TILE_RAYS = int(os.environ.get("ALGAN_WAVEFRONT_TILE", str(1 << 21)))
 # Opt in for memory-constrained renders, where shrinking tiles beats the
 # window-halving OOM retry.
 WAVEFRONT_TILE_AUTO = (
-    os.environ.get("ALGAN_WAVEFRONT_TILE_AUTO", "1") == "1"
-    and "ALGAN_WAVEFRONT_TILE" not in os.environ
+    env_flag("ALGAN_WAVEFRONT_TILE_AUTO", True)
+    and not env_is_set("ALGAN_WAVEFRONT_TILE")
 )
 # Fraction of the pool's free bytes the per-tile ray state may claim.  Every
 # built-in per-slot/fixed allocation and ManualMemory's initial alignment are
 # now accounted exactly, so the default can use the whole allowance.  Keep the
 # override as an opt-in diagnostic/performance headroom control.
-WAVEFRONT_TILE_SAFETY = float(os.environ.get("ALGAN_WAVEFRONT_TILE_SAFETY", "1.0"))
+WAVEFRONT_TILE_SAFETY = env_float("ALGAN_WAVEFRONT_TILE_SAFETY", 1.0)
 # Preferred lower bound and hard upper bound for auto tile size (rays). The
 # runtime honors the floor when it fits, but deliberately goes below it when
 # exact arena headroom requires a smaller tile; the cap bounds active-index
 # buffers and launch size on very large pools.
-WAVEFRONT_TILE_MIN = int(os.environ.get("ALGAN_WAVEFRONT_TILE_MIN", str(1 << 18)))
-WAVEFRONT_TILE_MAX = int(os.environ.get("ALGAN_WAVEFRONT_TILE_MAX", str(1 << 25)))
+WAVEFRONT_TILE_MIN = env_int("ALGAN_WAVEFRONT_TILE_MIN", 1 << 18)
+WAVEFRONT_TILE_MAX = env_int("ALGAN_WAVEFRONT_TILE_MAX", 1 << 25)
 
 
 def set_wavefront_tile_auto(enabled):
@@ -139,7 +139,7 @@ def set_wavefront_tile_auto(enabled):
 # Splitting paths retain the full-pool scan because a shade pass may activate a
 # spare slot that was not in the previous active set.  Runtime-mutable for
 # in-process A/B checks; the env var selects the startup default.
-WF_COMPACT_ACTIVE_ONLY = os.environ.get("ALGAN_WF_COMPACT_ACTIVE_ONLY", "1") == "1"
+WF_COMPACT_ACTIVE_ONLY = env_flag("ALGAN_WF_COMPACT_ACTIVE_ONLY", True)
 # Initial ratio of total shared ray-pool slots to primary rays for a tile that
 # may split. This is only a launch-efficiency heuristic, not a per-pixel or
 # per-path split limit: all pixels append continuations into one shared pool.
@@ -152,11 +152,9 @@ WF_COMPACT_ACTIVE_ONLY = os.environ.get("ALGAN_WF_COMPACT_ACTIVE_ONLY", "1") == 
 # controls only the initial ratio, never a hard maximum number of splits.
 REFRACT_INITIAL_POOL_RATIO = max(
     2,
-    int(
-        os.environ.get(
-            "ALGAN_WAVEFRONT_INITIAL_POOL_RATIO",
-            os.environ.get("ALGAN_WAVEFRONT_SPLIT", "2"),
-        )
+    env_int(
+        "ALGAN_WAVEFRONT_INITIAL_POOL_RATIO",
+        env_int("ALGAN_WAVEFRONT_SPLIT", 2),
     ),
 )
 # Backwards-compatible name for code that imported the old setting. It now
@@ -181,7 +179,7 @@ FRAGMENT_SHADING = True
 # stored constant, so a promoted render matches the per-vertex one to <=1 ULP
 # (the barycentric sum ``w0+w1+w2`` is not exactly 1.0 in f32). Default on;
 # ALGAN_PROMOTE_CONSTANTS=0 disables it (for A/B and validation).
-PROMOTE_CONSTANTS = os.environ.get("ALGAN_PROMOTE_CONSTANTS", "1") == "1"
+PROMOTE_CONSTANTS = env_flag("ALGAN_PROMOTE_CONSTANTS", True)
 
 # Skip the up-front per-fragment shading-normal computation for UNLIT hits on
 # the fragment-shading wavefront. An UNLIT material passes its colour through
@@ -193,7 +191,7 @@ PROMOTE_CONSTANTS = os.environ.get("ALGAN_PROMOTE_CONSTANTS", "1") == "1"
 # speed-relevant core of the "Family A" material-field trim (skipping the
 # normal work), decoupled from the memory-side array trimming.
 # ALGAN_WF_SKIP_UNLIT_NORMAL=0 disables it (for A/B and validation).
-WF_SKIP_UNLIT_NORMAL = os.environ.get("ALGAN_WF_SKIP_UNLIT_NORMAL", "1") == "1"
+WF_SKIP_UNLIT_NORMAL = env_flag("ALGAN_WF_SKIP_UNLIT_NORMAL", True)
 
 # Compile-time material-pipeline gating. The per-hit material dispatch
 # (``shading_taichi._run_frag_pipeline``) is inlined into the shade kernels
@@ -214,7 +212,7 @@ WF_SKIP_UNLIT_NORMAL = os.environ.get("ALGAN_WF_SKIP_UNLIT_NORMAL", "1") == "1"
 # raster resolve sits close enough to its occupancy cliff for the dropped
 # stages to matter. Hence experimental and off by default rather than on:
 # ALGAN_FRAG_PID_GATE=1 opts in.
-FRAG_PID_GATE = os.environ.get("ALGAN_FRAG_PID_GATE", "0") == "1"
+FRAG_PID_GATE = env_flag("ALGAN_FRAG_PID_GATE", False)
 
 
 def set_frag_pid_gate(enabled):
@@ -260,17 +258,17 @@ def _parse_gen_fused_mode(v):
     return "auto"
 
 
-WF_GEN_FUSED = _parse_gen_fused_mode(os.environ.get("ALGAN_WF_GEN_FUSED", "auto"))
+WF_GEN_FUSED = _parse_gen_fused_mode(env_str("ALGAN_WF_GEN_FUSED", "auto"))
 
 # Fraction of wavefront render time the fused generation saves (the measured
 # steady-state win; used only by the "auto" forecast).
-WF_GEN_FUSED_GAIN = float(os.environ.get("ALGAN_WF_GEN_FUSED_GAIN", "0.082"))
+WF_GEN_FUSED_GAIN = env_float("ALGAN_WF_GEN_FUSED_GAIN", 0.082)
 # Minimum forecasted saving (seconds of remaining render time * GAIN) before
 # "auto" pays the fused variants' compile cost. The default covers the
 # worst case observed on this project's hardware -- a cold offline cache,
 # where the two extra instantiations cost ~25 s -- so a marginal render never
 # loses time to the switch.
-WF_GEN_FUSED_MIN_WIN = float(os.environ.get("ALGAN_WF_GEN_FUSED_MIN_WIN", "30.0"))
+WF_GEN_FUSED_MIN_WIN = env_float("ALGAN_WF_GEN_FUSED_MIN_WIN", 30.0)
 
 # Adaptive state ("auto" mode only). The decision is process-sticky; the
 # batch counter restarts per render job so the forecast never uses the
@@ -292,7 +290,7 @@ _WF_GEN_FUSED_BATCHES = 0
 _SPARSE_DISCOVERY_BYTES_PER_FRAME = 0.0
 # Safety multiplier on the learned footprint: absorbs the small per-pair count
 # arrays, arena alignment, and modest coverage growth between adjacent chunks.
-SPARSE_DISCOVERY_SAFETY = float(os.environ.get("ALGAN_SPARSE_DISCOVERY_SAFETY", "1.25"))
+SPARSE_DISCOVERY_SAFETY = env_float("ALGAN_SPARSE_DISCOVERY_SAFETY", 1.25)
 
 
 def note_sparse_discovery_footprint(arena_bytes, num_frames):
@@ -382,7 +380,7 @@ def _note_batch_rendered(frames, seconds, frames_remaining):
 # occupancy-bound kernel; see benchmarks/_wf_mem_trim_ab.py). Byte-identical to
 # the baseline. Opt-in; only engaged for a no-shadow, non-refractive,
 # scatter-free triangle path (the common case). Default OFF.
-WF_MEM_TRIM = os.environ.get("ALGAN_WF_MEM_TRIM", "0") == "1"
+WF_MEM_TRIM = env_flag("ALGAN_WF_MEM_TRIM", False)
 
 # Shared-topology binned-SAH refit BVH (raytracer-v2 design doc section 9;
 # refit_bvh.py). When on, the per-batch scene merge builds ONE binned-SAH
@@ -402,7 +400,7 @@ WF_MEM_TRIM = os.environ.get("ALGAN_WF_MEM_TRIM", "0") == "1"
 # classic per-batch STBVH instance trees); note that while on, the triangle
 # ``builder`` selection (e.g. "split") applies only where the classic trees
 # are still built.
-BVH_REFIT = os.environ.get("ALGAN_BVH_REFIT", "1") == "1"
+BVH_REFIT = env_flag("ALGAN_BVH_REFIT", True)
 
 
 def set_refit_bvh(enabled):
@@ -423,7 +421,7 @@ def set_refit_bvh(enabled):
 # ray, or the Monte Carlo path needs them -- so the rendered output is always
 # exactly what the eager build produces. ALGAN_BVH_DEFER=0 disables (for A/B
 # and validation).
-BVH_DEFER = os.environ.get("ALGAN_BVH_DEFER", "1") == "1"
+BVH_DEFER = env_flag("ALGAN_BVH_DEFER", True)
 
 
 def set_bvh_defer(enabled):
@@ -444,7 +442,7 @@ def set_bvh_defer(enabled):
 # differs at the epsilon level, the same class as any window change).
 # ALGAN_MERGE_DEDUP_TIME=0 restores the full time bands (byte-level A/B
 # against pre-collapse baselines).
-MERGE_DEDUP_TIME = os.environ.get("ALGAN_MERGE_DEDUP_TIME", "1") == "1"
+MERGE_DEDUP_TIME = env_flag("ALGAN_MERGE_DEDUP_TIME", True)
 
 
 def set_merge_dedup_time(enabled):
@@ -478,8 +476,8 @@ def set_merge_dedup_time(enabled):
 # march's output up to the seam-merge corner the camera peel also has.
 SHADOW_ANYHIT = (
     "gather"
-    if os.environ.get("ALGAN_SHADOW_ANYHIT", "0").strip().lower() == "gather"
-    else os.environ.get("ALGAN_SHADOW_ANYHIT", "0") == "1"
+    if env_str("ALGAN_SHADOW_ANYHIT", "0").strip().lower() == "gather"
+    else env_flag("ALGAN_SHADOW_ANYHIT", False)
 )
 
 
@@ -505,7 +503,7 @@ def set_shadow_anyhit(enabled):
 # arena bytes. ALGAN_OPAQUE_BVH_SKIP_DEAD=0 restores the unconditional
 # builds (byte-level A/B: the skip also shrinks the merged scene the arena
 # planner measures).
-OPAQUE_BVH_SKIP_DEAD = os.environ.get("ALGAN_OPAQUE_BVH_SKIP_DEAD", "1") == "1"
+OPAQUE_BVH_SKIP_DEAD = env_flag("ALGAN_OPAQUE_BVH_SKIP_DEAD", True)
 
 
 def set_opaque_bvh_skip_dead(enabled):
@@ -538,7 +536,7 @@ def refit_bvh_active():
 # scatter, mem-trim, in-place AA, near clipping and legacy routes still fall
 # back to classic. Default ON (ALGAN_HYBRID_RASTER=0 restores the classic
 # iteration-zero wavefront).
-HYBRID_RASTER = os.environ.get("ALGAN_HYBRID_RASTER", "1") == "1"
+HYBRID_RASTER = env_flag("ALGAN_HYBRID_RASTER", True)
 
 
 def set_hybrid_raster(enabled):
@@ -555,7 +553,7 @@ def set_hybrid_raster(enabled):
 # Invalid/camera-plane-straddling projections fall back to exact per-pixel
 # Moller-Trumbore ray casting. ALGAN_RASTER_SS=0 forces ray casting for all
 # triangle candidates; the optimal policy may eventually be selected per pair.
-RASTER_SS = os.environ.get("ALGAN_RASTER_SS", "1") == "1"
+RASTER_SS = env_flag("ALGAN_RASTER_SS", True)
 
 
 def set_raster_screen_space(enabled):
@@ -574,7 +572,7 @@ def set_raster_screen_space(enabled):
 # Byte-identical by construction -- identical elementwise arithmetic, batched
 # over the frame dimension; validated by benchmarks/_raster_bez_pre_parity.py.
 # The toggle is a kill-switch / A-B hook.
-RASTER_BEZ_PRECOMPUTE = os.environ.get("ALGAN_RASTER_BEZ_PRECOMPUTE", "1") == "1"
+RASTER_BEZ_PRECOMPUTE = env_flag("ALGAN_RASTER_BEZ_PRECOMPUTE", True)
 
 
 def set_raster_bez_precompute(enabled):
@@ -589,7 +587,7 @@ def set_raster_bez_precompute(enabled):
 # class-mask derivation and candidate pair emission that ``_frame_pairs``
 # performed per (tile, frame) on top of the per-batch projection table.
 # Byte-identical by construction; same parity script.
-RASTER_TRI_PRECOMPUTE = os.environ.get("ALGAN_RASTER_TRI_PRECOMPUTE", "1") == "1"
+RASTER_TRI_PRECOMPUTE = env_flag("ALGAN_RASTER_TRI_PRECOMPUTE", True)
 
 
 def set_raster_tri_precompute(enabled):
@@ -616,7 +614,7 @@ def set_raster_tri_precompute(enabled):
 # full-window straddler bbox.  Parity: benchmarks/_raster_straddle_clip_parity.py;
 # the conservativeness proof is brute-forced by
 # benchmarks/_raster_clip_extents_check.py.
-RASTER_STRADDLE_CLIP = os.environ.get("ALGAN_RASTER_STRADDLE_CLIP", "1") == "1"
+RASTER_STRADDLE_CLIP = env_flag("ALGAN_RASTER_STRADDLE_CLIP", True)
 
 
 def set_raster_straddle_clip(enabled):
@@ -640,7 +638,7 @@ def set_raster_straddle_clip(enabled):
 # validated by benchmarks/_raster_empty_skip_parity.py.  Kill-switch / A-B
 # hook; read once per render batch so the host fill and the kernel template
 # always agree.
-RASTER_EMPTY_SKIP = os.environ.get("ALGAN_RASTER_EMPTY_SKIP", "1") == "1"
+RASTER_EMPTY_SKIP = env_flag("ALGAN_RASTER_EMPTY_SKIP", True)
 
 
 def set_raster_empty_skip(enabled):
@@ -660,7 +658,7 @@ def set_raster_empty_skip(enabled):
 # candidates.  Byte-identical: a skipped class is exactly one whose mask was
 # all-false, where ``_class_pairs_flat`` returned None anyway.  Same parity
 # script as RASTER_EMPTY_SKIP.
-RASTER_PAIR_FLAGS = os.environ.get("ALGAN_RASTER_PAIR_FLAGS", "1") == "1"
+RASTER_PAIR_FLAGS = env_flag("ALGAN_RASTER_PAIR_FLAGS", True)
 
 
 def set_raster_pair_flags(enabled):
@@ -683,7 +681,7 @@ def set_raster_pair_flags(enabled):
 # the sky in the resolve).  Byte-identical: the covered list is the ascending
 # nonzero order, so covered pixels are shaded in their original relative order
 # and skipped pixels do exactly what their early-out did (nothing).
-RASTER_COVERED_SHADE = os.environ.get("ALGAN_RASTER_COVERED_SHADE", "1") == "1"
+RASTER_COVERED_SHADE = env_flag("ALGAN_RASTER_COVERED_SHADE", True)
 
 
 def set_raster_covered_shade(enabled):
@@ -706,7 +704,7 @@ def set_raster_covered_shade(enabled):
 # and no environment map.  When an environment map is present every primary
 # pixel genuinely samples the sky, so full-screen state is coverage work rather
 # than empty overhead and the dense path remains correct.
-RASTER_SPARSE_COVERAGE = os.environ.get("ALGAN_RASTER_SPARSE_COVERAGE", "1") == "1"
+RASTER_SPARSE_COVERAGE = env_flag("ALGAN_RASTER_SPARSE_COVERAGE", True)
 
 
 def set_raster_sparse_coverage(enabled):
@@ -738,7 +736,7 @@ def set_raster_sparse_coverage(enabled):
 # refracted image), where the residual is the CONTENT of a minified secondary
 # image. Read DESIGN_analytic_aa.md ss19 before dropping ``anti_alias_level``
 # to 1; what is still untouched is texture minification (no mip chain).
-ANALYTIC_AA = os.environ.get("ALGAN_ANALYTIC_AA", "1") == "1"
+ANALYTIC_AA = env_flag("ALGAN_ANALYTIC_AA", True)
 
 # PHASE 2 (implemented): flat triangles. Coverage comes from the screen-space
 # edge functions ``_ss_pixel`` already evaluates, normalised by the edge lengths
@@ -750,7 +748,7 @@ ANALYTIC_AA = os.environ.get("ALGAN_ANALYTIC_AA", "1") == "1"
 # masks partition the pixel without a source-object side table.
 #
 # Subordinate per-geometry switches (only meaningful while ANALYTIC_AA is on).
-ANALYTIC_AA_BEZ = os.environ.get("ALGAN_ANALYTIC_AA_BEZ", "1") == "1"
+ANALYTIC_AA_BEZ = env_flag("ALGAN_ANALYTIC_AA_BEZ", True)
 #
 # Triangle coverage: exact fixed-point rasterization (a 1/4096-pixel integer
 # lattice, int64 edge functions and a top-left fill rule) partitions eight
@@ -761,14 +759,14 @@ ANALYTIC_AA_BEZ = os.environ.get("ALGAN_ANALYTIC_AA_BEZ", "1") == "1"
 # translucent one, sub-pixel rods, a slanted quad -- at 40-78% less error, with
 # essentially the reference's own edge gradation (588 distinct edge levels
 # against 608). See DESIGN_analytic_aa.md ss14-ss16.
-ANALYTIC_AA_TRI = os.environ.get("ALGAN_ANALYTIC_AA_TRI", "1") == "1"
+ANALYTIC_AA_TRI = env_flag("ALGAN_ANALYTIC_AA_TRI", True)
 
 # The seam rule itself. Off, coverage still scales alpha but consecutive
 # fragments of one object composite multiplicatively instead of unioning their
 # disjoint sub-areas -- which is the lattice this exists to remove. Kept as a
 # toggle purely so the parity script can measure the difference; there is no
 # reason to turn it off in a real render.
-ANALYTIC_AA_SEAM = os.environ.get("ALGAN_ANALYTIC_AA_SEAM", "1") == "1"
+ANALYTIC_AA_SEAM = env_flag("ALGAN_ANALYTIC_AA_SEAM", True)
 
 # What to do with a triangle that CONTAINS NO SUB-PIXEL SAMPLE. The exact
 # fixed-point test answers "does this triangle contain this sample"; a triangle
@@ -795,7 +793,7 @@ ANALYTIC_AA_SEAM = os.environ.get("ALGAN_ANALYTIC_AA_SEAM", "1") == "1"
 #
 # See DESIGN_analytic_aa.md ss15/ss16 for the measurements behind the default.
 ANALYTIC_AA_SLIVER_MODES = ("area", "exact", "drop", "exact_occ")
-ANALYTIC_AA_SLIVER = os.environ.get("ALGAN_ANALYTIC_AA_SLIVER", "drop")
+ANALYTIC_AA_SLIVER = env_str("ALGAN_ANALYTIC_AA_SLIVER", "drop")
 
 # Exact, angle-aware coverage for a circuit's boundary instead of a box filter
 # of its signed distance.
@@ -813,7 +811,7 @@ ANALYTIC_AA_SLIVER = os.environ.get("ALGAN_ANALYTIC_AA_SLIVER", "drop")
 # 2 exact) rather than as a constant, so each form gets its own compiled variant
 # and its own offline-cache entry -- the same trap the sliver policy avoids the
 # same way. See DESIGN_analytic_aa.md ss21.
-ANALYTIC_AA_EXACT = os.environ.get("ALGAN_ANALYTIC_AA_EXACT", "1") == "1"
+ANALYTIC_AA_EXACT = env_flag("ALGAN_ANALYTIC_AA_EXACT", True)
 
 # Model a circuit's local boundary with the TWO nearest segments (a strip or a
 # corner) instead of one half-plane -- THE ORIENTED WEDGE
@@ -827,7 +825,7 @@ ANALYTIC_AA_EXACT = os.environ.get("ALGAN_ANALYTIC_AA_EXACT", "1") == "1"
 # matched dilation the wedge beats both the box and the lone-exact arms on
 # stem/corner/glyph and improves slant -- the ss21.2 stem failure
 # (text -6.8% vs the box filter) is gone.
-ANALYTIC_AA_BEZ_WEDGE = os.environ.get("ALGAN_ANALYTIC_AA_BEZ_WEDGE", "1") == "1"
+ANALYTIC_AA_BEZ_WEDGE = env_flag("ALGAN_ANALYTIC_AA_BEZ_WEDGE", True)
 
 # The ss21.3/21.8/21.9 exact-triangle formulations (single exact area vs the
 # mask, packed cells, scalar surface accounting) are DELETED, not parked:
@@ -857,7 +855,7 @@ ANALYTIC_AA_BEZ_WEDGE = os.environ.get("ALGAN_ANALYTIC_AA_BEZ_WEDGE", "1") == "1
 # was calibrated on the rejected cells accounting -- see the ss8 Phase D
 # note). Worst-case cost is +6.6% frame device on sub-pixel-diced meshes;
 # RUN=0 is byte-identical to the pre-v2 renderer.
-ANALYTIC_AA_RUN = os.environ.get("ALGAN_ANALYTIC_AA_RUN", "1") == "1"
+ANALYTIC_AA_RUN = env_flag("ALGAN_ANALYTIC_AA_RUN", True)
 
 # The corr > 1 accounting rule (v2 ss4.4), the design's one open empirical
 # question, decided by harness: "clamp" scales the run's per-sample writes by
@@ -871,7 +869,7 @@ ANALYTIC_AA_RUN = os.environ.get("ALGAN_ANALYTIC_AA_RUN", "1") == "1"
 # reference's own 621, seam notches 9 vs 12, trans/thin at parity. Exact
 # leftovers cost two registers and a run-end scale.
 ANALYTIC_AA_RUN_RULES = ("clamp", "redistribute")
-ANALYTIC_AA_RUN_RULE = os.environ.get("ALGAN_ANALYTIC_AA_RUN_RULE", "redistribute")
+ANALYTIC_AA_RUN_RULE = env_str("ALGAN_ANALYTIC_AA_RUN_RULE", "redistribute")
 
 # Sub-pixel samples for what coverage CANNOT antialias analytically: the image
 # seen inside a reflection or through refracting glass. Coverage resolves a
@@ -889,7 +887,7 @@ ANALYTIC_AA_RUN_RULE = os.environ.get("ALGAN_ANALYTIC_AA_RUN_RULE", "redistribut
 # The split happens ONCE, at the primary hit; deeper bounces continue as single
 # rays, so the cost is N times the secondary traversal, not N^depth. Only the
 # reflective/refractive pixels pay it. 1 disables it, and is byte-identical.
-ANALYTIC_AA_SECONDARY_SAMPLES = int(os.environ.get("ALGAN_ANALYTIC_AA_SECONDARY", "4"))
+ANALYTIC_AA_SECONDARY_SAMPLES = env_int("ALGAN_ANALYTIC_AA_SECONDARY", 4)
 
 # Minimum share of a pixel a REFLECTED or REFRACTED branch must carry before it
 # is worth spending N sub-pixel continuations on instead of one.
@@ -899,9 +897,7 @@ ANALYTIC_AA_SECONDARY_SAMPLES = int(os.environ.get("ALGAN_ANALYTIC_AA_SECONDARY"
 # pixel for a lobe contributing 4% of its colour, and measures both slower and
 # slightly worse than plain supersampling. The whole value of coverage is that
 # the expensive fallbacks fire only on the pixels that need them.
-ANALYTIC_AA_SECONDARY_MIN_ENERGY = float(
-    os.environ.get("ALGAN_ANALYTIC_AA_SECONDARY_MIN_ENERGY", "0.12")
-)
+ANALYTIC_AA_SECONDARY_MIN_ENERGY = env_float("ALGAN_ANALYTIC_AA_SECONDARY_MIN_ENERGY", 0.12)
 
 # Roughness-driven GLOSSY REFLECTION for the deterministic tracer: a rough
 # reflector's continuation rays spread over a GGX lobe instead of all taking the
@@ -925,7 +921,7 @@ ANALYTIC_AA_SECONDARY_MIN_ENERGY = float(
 # a true mirror is byte-identical to the pre-glossy build.
 #
 # See DESIGN_analytic_aa.md ss20.
-GLOSSY_REFLECTION = os.environ.get("ALGAN_GLOSSY_REFLECTION", "1") == "1"
+GLOSSY_REFLECTION = env_flag("ALGAN_GLOSSY_REFLECTION", True)
 
 # Rotate each pixel's lobe fan by a 4x4 Bayer index (interleaved sampling), so
 # four taps read as a smear rather than four ghost copies of the reflected
@@ -933,7 +929,7 @@ GLOSSY_REFLECTION = os.environ.get("ALGAN_GLOSSY_REFLECTION", "1") == "1"
 # integrates across them. Fixed in SCREEN space, hence still frame-independent
 # -- the pattern does not swim, twinkle or depend on time. Off restores the
 # plain per-fragment fan (kept so the parity script can measure the difference).
-GLOSSY_INTERLEAVE = os.environ.get("ALGAN_GLOSSY_INTERLEAVE", "1") == "1"
+GLOSSY_INTERLEAVE = env_flag("ALGAN_GLOSSY_INTERLEAVE", True)
 
 
 def set_glossy_reflection(enabled, *, interleave=None):
@@ -966,9 +962,7 @@ def glossy_reflection_mode():
 # reference AA=2 it dilates by 0.3 output pixels, at AA=1 by 0.6. Analytic AA
 # runs at AA=1, so 0.3 reproduces the reference appearance rather than doubling
 # every stroke weight. Tune only against rendered Text/Tex.
-ANALYTIC_AA_BEZ_MIN_HALF_WIDTH = float(
-    os.environ.get("ALGAN_ANALYTIC_AA_BEZ_MIN_HALF_WIDTH", "0.3")
-)
+ANALYTIC_AA_BEZ_MIN_HALF_WIDTH = env_float("ALGAN_ANALYTIC_AA_BEZ_MIN_HALF_WIDTH", 0.3)
 
 # Maximum curve-to-chord flattening error, in pixels, for Bezier circuits under
 # analytic AA (overrides the primitive's own ``num_pixels_per_sample`` only when
@@ -976,9 +970,7 @@ ANALYTIC_AA_BEZ_MIN_HALF_WIDTH = float(
 # at the AA=2 reference it is 0.25 output pixels; at AA=1 it would relax to 0.5
 # and a continuous coverage function would expose the flattening facets that box
 # filtering currently hides. Costs edges (memory + _bezier_point_metrics work).
-ANALYTIC_AA_CHORD_TOLERANCE = float(
-    os.environ.get("ALGAN_ANALYTIC_AA_CHORD_TOLERANCE", "0.25")
-)
+ANALYTIC_AA_CHORD_TOLERANCE = env_float("ALGAN_ANALYTIC_AA_CHORD_TOLERANCE", 0.25)
 
 
 def set_analytic_aa(
@@ -1126,7 +1118,7 @@ def set_textured_wavefront(enabled):
 # headroom before the merge is attempted and (b) caught by the existing
 # OOM -> window-shrink retry if the estimate was low. Off falls back to the
 # byte-exact CPU build. ALGAN_MERGE_ON_GPU=0 disables.
-MERGE_ON_GPU = os.environ.get("ALGAN_MERGE_ON_GPU", "1") == "1"
+MERGE_ON_GPU = env_flag("ALGAN_MERGE_ON_GPU", True)
 
 # Multiplier turning a batch's packed ``_rt_*`` input bytes into a conservative
 # estimate of the GPU merge's transient peak (the out-of-place cat / argsort /
@@ -1140,7 +1132,7 @@ MERGE_ON_GPU = os.environ.get("ALGAN_MERGE_ON_GPU", "1") == "1"
 # their packed inputs. It is deliberately generous: torch's allocator counters
 # cannot see Taichi's separate pool at all, and the out-of-memory handler is
 # the exact fallback when the estimate is low.
-MERGE_GPU_PEAK_FACTOR = float(os.environ.get("ALGAN_MERGE_GPU_PEAK_FACTOR", "6.0"))
+MERGE_GPU_PEAK_FACTOR = env_float("ALGAN_MERGE_GPU_PEAK_FACTOR", 6.0)
 
 
 def merge_gpu_peak_factor():
@@ -1156,7 +1148,7 @@ def merge_gpu_peak_factor():
 # remember the displaced high-water mark, so measuring costs a pair of cheap
 # counter reads and nothing else -- hence on by default. The headroom bound
 # itself is still the ``MERGE_GPU_PEAK_FACTOR`` estimate.
-MERGE_TRACK_PEAK = os.environ.get("ALGAN_MERGE_TRACK_PEAK", "1") == "1"
+MERGE_TRACK_PEAK = env_flag("ALGAN_MERGE_TRACK_PEAK", True)
 
 
 def set_merge_on_gpu(enabled):
@@ -1191,7 +1183,7 @@ def merge_on_gpu_active():
 # consume with no upload. The heavy Python-bound timeline materialization
 # (``set_state_to_times``) is what still rides the hidden worker. Off keeps
 # projection on the CPU source device. ALGAN_PROJECT_ON_GPU=0 disables.
-PROJECT_ON_GPU = os.environ.get("ALGAN_PROJECT_ON_GPU", "1") == "1"
+PROJECT_ON_GPU = env_flag("ALGAN_PROJECT_ON_GPU", True)
 
 # Conservative multiplier from a batch's pre-projection source-geometry bytes
 # to the projection's transient device peak (source + shading scratch + packed
@@ -1199,7 +1191,7 @@ PROJECT_ON_GPU = os.environ.get("ALGAN_PROJECT_ON_GPU", "1") == "1"
 # its control points, hence a larger default than the merge factor). Bounds the
 # projection against the pool headroom before it is attempted; the OOM retry is
 # the exact fallback. Read live.
-PROJECT_GPU_PEAK_FACTOR = float(os.environ.get("ALGAN_PROJECT_GPU_PEAK_FACTOR", "8.0"))
+PROJECT_GPU_PEAK_FACTOR = env_float("ALGAN_PROJECT_GPU_PEAK_FACTOR", 8.0)
 
 
 def project_gpu_peak_factor():
@@ -1247,7 +1239,7 @@ def project_on_gpu_active():
 # live on the CPU, where launching Taichi against them stages every argument
 # through VRAM (see generate_array_states' docstring), and projection may run
 # on the prefetch worker rather than the render thread.
-PN_CRITERION_KERNEL = os.environ.get("ALGAN_PN_CRITERION_KERNEL", "1") == "1"
+PN_CRITERION_KERNEL = env_flag("ALGAN_PN_CRITERION_KERNEL", True)
 
 
 def set_pn_criterion_kernel(enabled):
@@ -1273,7 +1265,7 @@ WF_TEX_BEZ = 1  # bezier-circuit traversal + shading
 WF_TEX_SCATTER = 2  # per-material custom scatter dispatch (ray bouncing)
 WF_TEX_SHADOWS = 4  # binary hard shadow rays (triangle occluders)
 WF_TEX_NORMALMAP = 8  # tangent-space normal-map perturbation of the shading normal
-WF_TEXTURED_FEATURES = int(os.environ.get("ALGAN_WF_TEXTURED_FEATURES", "0"))
+WF_TEXTURED_FEATURES = env_int("ALGAN_WF_TEXTURED_FEATURES", 0)
 
 
 def set_textured_features(mask):
@@ -1481,7 +1473,7 @@ def hdr_frame_dtype():
     return torch.float32
 
 
-POST_TONEMAP_KERNEL = os.environ.get("ALGAN_POST_TONEMAP_KERNEL", "1") == "1"
+POST_TONEMAP_KERNEL = env_flag("ALGAN_POST_TONEMAP_KERNEL", True)
 
 
 def set_post_tonemap_kernel(enabled):

--- a/algan/rendering/raytracing/settings.py
+++ b/algan/rendering/raytracing/settings.py
@@ -105,9 +105,8 @@ WAVEFRONT_TILE_RAYS = env_int("ALGAN_WAVEFRONT_TILE", 1 << 21)
 # buy nothing (the profiler's per-kernel syncs made launches look expensive).
 # Opt in for memory-constrained renders, where shrinking tiles beats the
 # window-halving OOM retry.
-WAVEFRONT_TILE_AUTO = (
-    env_flag("ALGAN_WAVEFRONT_TILE_AUTO", True)
-    and not env_is_set("ALGAN_WAVEFRONT_TILE")
+WAVEFRONT_TILE_AUTO = env_flag("ALGAN_WAVEFRONT_TILE_AUTO", True) and not env_is_set(
+    "ALGAN_WAVEFRONT_TILE"
 )
 # Fraction of the pool's free bytes the per-tile ray state may claim.  Every
 # built-in per-slot/fixed allocation and ManualMemory's initial alignment are
@@ -897,7 +896,9 @@ ANALYTIC_AA_SECONDARY_SAMPLES = env_int("ALGAN_ANALYTIC_AA_SECONDARY", 4)
 # pixel for a lobe contributing 4% of its colour, and measures both slower and
 # slightly worse than plain supersampling. The whole value of coverage is that
 # the expensive fallbacks fire only on the pixels that need them.
-ANALYTIC_AA_SECONDARY_MIN_ENERGY = env_float("ALGAN_ANALYTIC_AA_SECONDARY_MIN_ENERGY", 0.12)
+ANALYTIC_AA_SECONDARY_MIN_ENERGY = env_float(
+    "ALGAN_ANALYTIC_AA_SECONDARY_MIN_ENERGY", 0.12
+)
 
 # Roughness-driven GLOSSY REFLECTION for the deterministic tracer: a rough
 # reflector's continuation rays spread over a GGX lobe instead of all taking the

--- a/algan/rendering/raytracing/shading_taichi.py
+++ b/algan/rendering/raytracing/shading_taichi.py
@@ -47,9 +47,10 @@ its multi-light behaviour: each light is applied in sequence with the running
 colour as the albedo (the renderer's vertex path overwrites the colour per
 light), which is identical to a single light -- the common case.
 """
-import os
 
 import taichi as ti
+
+from algan.environment import env_int
 
 # Width of the built-in per-primitive material parameter block (see slot map).
 MAT_W = 26
@@ -84,7 +85,7 @@ AMBIENT_STRENGTH = 0.1
 # shader's base fade-out is power-fraction weighted -- see _stage_default). A
 # truly unbounded (runtime) count would need the per-fragment visibilities in
 # a global scratch buffer instead of a stack vector.
-MAX_SHADOW_LIGHTS = max(1, int(os.environ.get("ALGAN_MAX_SHADOW_LIGHTS", "16")))
+MAX_SHADOW_LIGHTS = max(1, env_int("ALGAN_MAX_SHADOW_LIGHTS", 16))
 
 
 @ti.func

--- a/algan/rendering/raytracing/stbvh.py
+++ b/algan/rendering/raytracing/stbvh.py
@@ -39,9 +39,9 @@ the wavefront and Monte Carlo kernels alike).
 
 from __future__ import annotations
 
-import os
-
 import torch
+
+from algan.environment import env_flag, env_float, env_int, env_str
 
 # Bounds used to mark an empty/invisible AABB. Unions and costs are computed
 # with clamping so that empty boxes behave as the identity element. The
@@ -61,7 +61,7 @@ _QUANT_BITS = 15  # 4 * 15 = 60 bits used, keeping codes positive in int64.
 # then mostly rejected by their frame intervals. Default to one instance per
 # leaf; the env knob remains for experiments. Read once at import (the
 # traversal kernels specialize on it).
-LEAF_SIZE = max(1, int(os.environ.get("ALGAN_STBVH_LEAF_SIZE", "1")))
+LEAF_SIZE = max(1, env_int("ALGAN_STBVH_LEAF_SIZE", 1))
 
 # Branching factor of the implicit tree. A wider tree is shallower -- depth
 # divides by log2(BVH_ARITY) -- which shortens the serial chain of dependent
@@ -72,14 +72,14 @@ LEAF_SIZE = max(1, int(os.environ.get("ALGAN_STBVH_LEAF_SIZE", "1")))
 # level outweigh the further depth cut). 2 reproduces the original binary
 # layout. Read once at import; the traversal kernels specialize on it. Must
 # be >= 2.
-BVH_ARITY = max(2, int(os.environ.get("ALGAN_BVH_ARITY", "4")))
+BVH_ARITY = max(2, env_int("ALGAN_BVH_ARITY", 4))
 
 # Relative weight of the (normalized) time axis in the median-split builder's
 # widest-axis choice. > 1 makes time splits happen higher in the tree, so
 # subtrees become frame-pure sooner and the traversal's frame gate rejects
 # them wholesale for rays in other frames. Purely a build-quality knob: the
 # traversal is arrangement-invariant, so renders are byte-identical.
-SPLIT_TIME_WEIGHT = float(os.environ.get("ALGAN_SPLIT_TIME_WEIGHT", "1"))
+SPLIT_TIME_WEIGHT = env_float("ALGAN_SPLIT_TIME_WEIGHT", 1.0)
 
 # Store the sibling-block child bounds as conservatively rounded float16
 # (64-byte blocks) instead of exact float32 (128-byte blocks). Lower bounds
@@ -93,7 +93,7 @@ SPLIT_TIME_WEIGHT = float(os.environ.get("ALGAN_SPLIT_TIME_WEIGHT", "1"))
 # ALGAN_BVH_BLOCK_F16=0 opts out (exact f32 blocks). Read once at import by
 # both this module (build) and the traversal kernels (block decode + ndarray
 # element type).
-BLOCK_F16 = os.environ.get("ALGAN_BVH_BLOCK_F16", "1") == "1"
+BLOCK_F16 = env_flag("ALGAN_BVH_BLOCK_F16", True)
 
 # Smallest normal float16. Conservative rounding pushes would-be-subnormal
 # magnitudes outward to 0 or +-this, so a flush-to-zero f16->f32 conversion
@@ -306,7 +306,7 @@ def _quantize(c, lo, hi):
 # the epsilon level there -- faster, but kept off to preserve baselines).
 # Setting ALGAN_BVH_BUILD forces one builder for every type (A/B escape
 # hatch).
-_BVH_BUILD = os.environ.get("ALGAN_BVH_BUILD")
+_BVH_BUILD = env_str("ALGAN_BVH_BUILD", None)
 
 
 def _median_split_slots(centers, P):

--- a/algan/rendering/taichi_runtime.py
+++ b/algan/rendering/taichi_runtime.py
@@ -37,6 +37,7 @@ import time
 import taichi as ti
 import torch
 
+from algan.environment import env_flag, env_int, env_str
 from algan.settings._startup import _RENDER_DEVICE, _TAICHI_CACHE_DIRECTORY
 
 _COMPILE_LOG_LOCK = threading.Lock()
@@ -46,11 +47,11 @@ _COMPILE_NOTICE_THREAD_ID = None
 
 
 def _compile_logging_enabled():
-    return os.environ.get("ALGAN_LOG_TAICHI_COMPILES", "0") != "0"
+    return env_flag("ALGAN_LOG_TAICHI_COMPILES", False)
 
 
 def _compile_log_path():
-    path = os.environ.get("ALGAN_TAICHI_COMPILE_LOG", "").strip()
+    path = env_str("ALGAN_TAICHI_COMPILE_LOG", "").strip()
     return os.path.abspath(os.path.expanduser(path)) if path else ""
 
 
@@ -388,13 +389,13 @@ def taichi_init_kwargs():
         "fast_math": True,
         # advanced_optimization defaults off (it raised register
         # pressure on the big megakernels); env ALGAN_ADV_OPT=1 to A/B.
-        "advanced_optimization": os.environ.get("ALGAN_ADV_OPT", "0") == "1",
+        "advanced_optimization": env_flag("ALGAN_ADV_OPT", False),
         # debug=True inserts a bounds-check on *every* ndarray access;
         # the ray-trace megakernels do millions of array reads per ray
         # (BVH nodes, packed geometry), so it ran them ~11x slower with
         # no benefit to released renders. Keep it off (env ALGAN_TI_DEBUG=1
         # re-enables it for kernel development).
-        "debug": os.environ.get("ALGAN_TI_DEBUG", "0") == "1",
+        "debug": env_flag("ALGAN_TI_DEBUG", False),
         "offline_cache": True,
         # The default 100 MB cache LRU-evicts large megakernel
         # artifacts once several variants (general / no-PN / lean /
@@ -411,12 +412,12 @@ def taichi_init_kwargs():
     # the TI_OFFLINE_CACHE_FILE_PATH env var (Taichi warns and ignores the
     # env), so only pass it when the env var is unset to keep that standard
     # escape hatch working.
-    if not os.environ.get("TI_OFFLINE_CACHE_FILE_PATH"):
+    if not env_str("TI_OFFLINE_CACHE_FILE_PATH"):
         kwargs["offline_cache_file_path"] = str(_TAICHI_CACHE_DIRECTORY)
-    max_reg = int(os.environ.get("ALGAN_GPU_MAX_REG", "0"))
+    max_reg = env_int("ALGAN_GPU_MAX_REG", 0)
     if max_reg > 0:
         kwargs["gpu_max_reg"] = max_reg
-    opt_level = int(os.environ.get("ALGAN_OPT_LEVEL", "0"))
+    opt_level = env_int("ALGAN_OPT_LEVEL", 0)
     if opt_level > 0:
         kwargs["opt_level"] = opt_level
     return kwargs

--- a/algan/settings/_startup.py
+++ b/algan/settings/_startup.py
@@ -20,6 +20,7 @@ os.environ.setdefault("CUDA_CACHE_MAXSIZE", "4294967296")
 
 import torch
 
+from algan.environment import env_flag, env_int, env_str
 from algan.errors import AlganConfigurationError
 
 
@@ -43,7 +44,7 @@ def _auto_render_device() -> torch.device:
 
 
 def _parse_device(env_name: str, default: str | torch.device) -> torch.device:
-    raw = os.environ.get(env_name, str(default)).strip().lower()
+    raw = env_str(env_name, str(default)).strip().lower()
     if raw == "auto":
         return _auto_render_device()
     try:
@@ -68,14 +69,14 @@ def _parse_device(env_name: str, default: str | torch.device) -> torch.device:
 _ANIMATION_DEVICE = _parse_device("ALGAN_ANIMATION_DEVICE", "cpu")
 _RENDER_DEVICE = _parse_device("ALGAN_RENDER_DEVICE", "auto")
 
-_ALGAN_HOME = Path(os.environ.get("ALGAN_HOME", Path.home() / ".algan")).expanduser()
+_ALGAN_HOME = Path(env_str("ALGAN_HOME") or Path.home() / ".algan").expanduser()
 _CACHE_DIRECTORY = Path(
-    os.environ.get("ALGAN_CACHE_DIR", _ALGAN_HOME / "cache")
+    env_str("ALGAN_CACHE_DIR") or _ALGAN_HOME / "cache"
 ).expanduser()
 _TAICHI_CACHE_DIRECTORY = Path(
-    os.environ.get("TI_OFFLINE_CACHE_FILE_PATH", _CACHE_DIRECTORY / "taichi")
+    env_str("TI_OFFLINE_CACHE_FILE_PATH") or _CACHE_DIRECTORY / "taichi"
 ).expanduser()
 
 # These are baked into Taichi kernels or runtime layout at first materialisation.
-_SOFT_SHADOW_SAMPLES = max(2, int(os.environ.get("ALGAN_SOFT_SHADOW_SAMPLES", "8")))
-_HDR_BUFFER_F16 = os.environ.get("ALGAN_HDR_BUFFER_F16", "0") == "1"
+_SOFT_SHADOW_SAMPLES = max(2, env_int("ALGAN_SOFT_SHADOW_SAMPLES", 8))
+_HDR_BUFFER_F16 = env_flag("ALGAN_HDR_BUFFER_F16", False)

--- a/algan/utils/manim_svg_cache.py
+++ b/algan/utils/manim_svg_cache.py
@@ -52,6 +52,7 @@ from pathlib import Path
 import numpy as np
 import torch
 
+from algan.environment import env_float
 from algan.logging.logger import get_logger
 from algan.settings import SETTINGS
 
@@ -81,11 +82,7 @@ _DEFAULT_CACHE_MB = 1024
 
 
 def _max_cache_bytes() -> int:
-    try:
-        mb = float(os.environ.get("ALGAN_MANIM_SVG_CACHE_MB", _DEFAULT_CACHE_MB))
-    except ValueError:
-        mb = _DEFAULT_CACHE_MB
-    return int(mb * 1024 * 1024)
+    return int(env_float("ALGAN_MANIM_SVG_CACHE_MB", _DEFAULT_CACHE_MB) * 1024 * 1024)
 
 
 def _cache_dir() -> Path:

--- a/algan/utils/profiling_utils.py
+++ b/algan/utils/profiling_utils.py
@@ -84,6 +84,7 @@ import algan.rendering.raytracing.stbvh as stbvh_mod
 import algan.rendering.raytracing.tracer as rtr
 from algan import KERNEL_REGISTRY
 from algan.animatable_base.animatable import Animatable
+from algan.environment import env_flag, env_int, env_overrides
 from algan.mobs.bezier_circuit import BezierCircuitCubic
 from algan.mobs.surfaces.surface import Surface
 from algan.scene import Scene
@@ -948,7 +949,7 @@ def nvprof_command_hint(script_argv):
 
 def under_nvprof():
     """True when running as the child of an nvprof launch (see profile_scene)."""
-    return os.environ.get("ALGAN_UNDER_NVPROF") == "1"
+    return env_flag("ALGAN_UNDER_NVPROF", False)
 
 
 def _parse_nvprof_csv(text):
@@ -1008,7 +1009,7 @@ def run_nvprof_metrics(script_argv, timeout=1200):
     """
     if not _which("nvprof") or under_nvprof() or not script_argv:
         return None
-    env = dict(os.environ, ALGAN_UNDER_NVPROF="1")
+    env = dict(os.environ, **env_overrides(ALGAN_UNDER_NVPROF="1"))
     py = sys.executable
     merged = {}
     for extra in (
@@ -1053,7 +1054,7 @@ def run_once(scene_func, settings, tag="", run_index=0, telemetry=True):
     sampler = GpuTelemetrySampler().start() if telemetry else None
     # cProfile is opt-in (ALGAN_PROFILE_CPROFILE=1): its per-call overhead
     # inflates the python-side numbers, so the default report is wall-clean.
-    use_cprofile = os.environ.get("ALGAN_PROFILE_CPROFILE", "0") == "1"
+    use_cprofile = env_flag("ALGAN_PROFILE_CPROFILE", False)
     profiler = cProfile.Profile() if use_cprofile else None
     _sync_devices()
     t0 = time.perf_counter()
@@ -1356,13 +1357,13 @@ def profile_scene(
         return
 
     if runs is None:
-        runs = int(os.environ.get("ALGAN_PROFILE_RUNS", "2"))
+        runs = env_int("ALGAN_PROFILE_RUNS", 2)
     if kernel_profiler is None:
-        kernel_profiler = os.environ.get("ALGAN_TI_KERNEL_PROFILER", "1") == "1"
+        kernel_profiler = env_flag("ALGAN_TI_KERNEL_PROFILER", True)
     if telemetry is None:
-        telemetry = os.environ.get("ALGAN_PROFILE_TELEMETRY", "1") == "1"
+        telemetry = env_flag("ALGAN_PROFILE_TELEMETRY", True)
     if nvprof is None:
-        nvprof = os.environ.get("ALGAN_PROFILE_NVPROF", "0") == "1"
+        nvprof = env_flag("ALGAN_PROFILE_NVPROF", False)
 
     if kernel_profiler:
         enable_taichi_kernel_profiler()

--- a/algan/utils/taichi_fast_launch.py
+++ b/algan/utils/taichi_fast_launch.py
@@ -54,7 +54,7 @@ only; silent no-op anywhere else (or when ``ALGAN_TAICHI_FAST_LAUNCH=0``).
 
 from __future__ import annotations
 
-import os
+from algan.environment import env_flag
 
 _APPLIED = False
 
@@ -84,7 +84,7 @@ def apply():
     global _APPLIED
     if _APPLIED:
         return
-    if os.environ.get("ALGAN_TAICHI_FAST_LAUNCH", "1") == "0":
+    if not env_flag("ALGAN_TAICHI_FAST_LAUNCH", True):
         return
     try:
         import numpy as np
@@ -110,7 +110,7 @@ def apply():
 
     _orig_call = kernel_cls.__call__
     _orig_reset = kernel_cls.reset
-    _verify = os.environ.get("ALGAN_TAICHI_FAST_LAUNCH_VERIFY", "0") == "1"
+    _verify = env_flag("ALGAN_TAICHI_FAST_LAUNCH_VERIFY", False)
     _template_t = _ki.template
     _ndarray_t = _ki.ndarray_type.NdarrayType
     _real_ids = _ki.primitive_types.real_type_ids

--- a/algan/utils/taichi_warmstart.py
+++ b/algan/utils/taichi_warmstart.py
@@ -40,8 +40,9 @@ from __future__ import annotations
 
 import ast
 import contextlib
-import os
 import textwrap
+
+from algan.environment import env_flag
 
 _APPLIED = False
 
@@ -51,7 +52,7 @@ def apply():
     global _APPLIED
     if _APPLIED:
         return
-    if os.environ.get("ALGAN_TAICHI_WARMSTART", "1") == "0":
+    if not env_flag("ALGAN_TAICHI_WARMSTART", True):
         return
 
     try:
@@ -91,7 +92,7 @@ def apply():
     # original implementation and raises on any byte difference (used by
     # benchmarks/_taichi_warmstart_check.py).
     _orig_get_pos_info = ctx_cls.get_pos_info
-    _verify = os.environ.get("ALGAN_TAICHI_WARMSTART_VERIFY", "0") == "1"
+    _verify = env_flag("ALGAN_TAICHI_WARMSTART_VERIFY", False)
 
     def _wrap80(text):
         if len(text) <= 80:

--- a/tests/README.md
+++ b/tests/README.md
@@ -278,7 +278,10 @@ Organised by subsystem. The files worth knowing about:
   layout, hierarchy, and the actor registration that decides whether geometry
   reaches the renderer at all.
 - `test_settings_api.py`, `test_environment.py` — the `SETTINGS` root, its
-  validation, the experimental-switch gate, and the startup-only environment.
+  validation, the experimental-switch gate, and the environment: how `ALGAN_`
+  variables parse, and the rule that the package reaches them only through
+  `algan/environment.py`'s accessors (which is what keeps its registry of
+  declared names honest).
 - `test_materials.py`, `test_fragment_shaders.py`, `test_indication_animations.py`,
   `test_rate_functions.py` — the authoring surface users touch most.
 - `test_memory_model.py`, `test_render_batch_sizing.py`, `test_manual_memory.py` —

--- a/tests/unit_tests/test_environment.py
+++ b/tests/unit_tests/test_environment.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import ast
 import os
-import re
 import subprocess
 import sys
 import warnings
@@ -11,33 +11,185 @@ import pytest
 
 from algan.environment import (
     ALGAN_ENVIRONMENT_VARIABLES,
+    env_flag,
+    env_float,
+    env_int,
+    env_is_set,
+    env_overrides,
+    env_str,
+    startup_environment_variables,
     unknown_algan_environment_variables,
     warn_for_unknown_algan_environment_variables,
 )
-from algan.errors import AlganWarning
+from algan.errors import AlganConfigurationError, AlganWarning
 
 
-def test_environment_registry_matches_package_environment_reads():
-    source_root = Path(__file__).parents[2] / "algan"
-    patterns = (
-        r"os\.(?:getenv|environ\.get)\(\s*['\"](ALGAN_[A-Z0-9_]+)",
-        r"os\.environ\[\s*['\"](ALGAN_[A-Z0-9_]+)",
-        r"['\"](ALGAN_[A-Z0-9_]+)['\"]\s+(?:not\s+)?in\s+os\.environ",
-        r"_parse_device\(\s*['\"](ALGAN_[A-Z0-9_]+)",
-        r"dict\(os\.environ,\s*(ALGAN_[A-Z0-9_]+)\s*=",
+def _own_nodes(statement):
+    """Every node belonging to ``statement`` itself, not to statements inside it."""
+    stack = [statement]
+    while stack:
+        node = stack.pop()
+        yield node
+        stack.extend(
+            child
+            for child in ast.iter_child_nodes(node)
+            if not isinstance(child, ast.stmt)
+        )
+
+
+def _is_environ_access(node):
+    return (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "os"
+        and node.attr in ("environ", "getenv")
     )
-    used = set()
+
+
+def _is_environ_subscript_write(statement):
+    targets = getattr(statement, "targets", None) or [getattr(statement, "target", None)]
+    return any(
+        isinstance(target, ast.Subscript) and _is_environ_access(target.value)
+        for target in targets
+        if target is not None
+    )
+
+
+#: Names reached through one of these are accounted for, even when the same
+#: statement also touches ``os.environ`` (``dict(os.environ, **env_overrides(...))``).
+_ACCESSORS = frozenset(
+    {"env_flag", "env_float", "env_int", "env_is_set", "env_overrides", "env_str"}
+)
+
+
+def _algan_names(nodes):
+    accounted = set()
+    for node in nodes:
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in _ACCESSORS
+        ):
+            accounted.update(id(child) for child in ast.walk(node))
+    literals = {
+        node.value
+        for node in nodes
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and node.value.startswith("ALGAN_")
+        and id(node) not in accounted
+    }
+    keywords = {
+        node.arg
+        for node in nodes
+        if isinstance(node, ast.keyword)
+        and (node.arg or "").startswith("ALGAN_")
+        and id(node) not in accounted
+    }
+    return sorted(literals | keywords)
+
+
+def test_package_reaches_algan_variables_only_through_the_accessors():
+    """The one rule that keeps the registry in algan/environment.py honest.
+
+    Every ``ALGAN_`` read goes through an ``env_*`` accessor, which rejects a
+    name that is not declared -- so a knob added without a declaration fails
+    loudly on its first read instead of becoming a variable users can misspell
+    without warning. This test is what stops the package from routing around
+    that, and it needs no maintenance as variables come and go.
+
+    Writes through ``os.environ[...]`` are allowed: :mod:`algan.daemon` has to
+    set ``ALGAN_DAEMON_CHILD`` before importing algan at all, and a misspelled
+    write surfaces as an unknown-variable warning in the child process.
+    """
+    source_root = Path(__file__).parents[2] / "algan"
+    violations = []
     for source_path in source_root.rglob("*.py"):
         if (
             "external_libraries" in source_path.parts
             or source_path.name == "environment.py"
         ):
             continue
-        source = source_path.read_text(encoding="utf-8")
-        for pattern in patterns:
-            used.update(re.findall(pattern, source))
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        for statement in ast.walk(tree):
+            if not isinstance(statement, ast.stmt):
+                continue
+            if _is_environ_subscript_write(statement):
+                continue
+            nodes = list(_own_nodes(statement))
+            if not any(_is_environ_access(node) for node in nodes):
+                continue
+            for name in _algan_names(nodes):
+                violations.append(
+                    f"{source_path.relative_to(source_root.parent)}:"
+                    f"{statement.lineno}: {name}"
+                )
 
-    assert used == ALGAN_ENVIRONMENT_VARIABLES
+    assert not violations, (
+        "read these through algan.environment's env_* accessors instead of os:\n"
+        + "\n".join(violations)
+    )
+
+
+def test_undeclared_names_are_rejected_by_every_accessor():
+    for read in (
+        lambda: env_str("ALGAN_NOT_DECLARED"),
+        lambda: env_flag("ALGAN_NOT_DECLARED", False),
+        lambda: env_int("ALGAN_NOT_DECLARED", 1),
+        lambda: env_float("ALGAN_NOT_DECLARED", 1.0),
+        lambda: env_is_set("ALGAN_NOT_DECLARED"),
+        lambda: env_overrides(ALGAN_NOT_DECLARED="1"),
+    ):
+        with pytest.raises(AlganConfigurationError, match="not a declared"):
+            read()
+
+
+def test_startup_variables_are_declared_and_ordered():
+    startup = startup_environment_variables()
+    assert startup[:2] == ("ALGAN_ANIMATION_DEVICE", "ALGAN_RENDER_DEVICE")
+    assert "TI_OFFLINE_CACHE_FILE_PATH" in startup
+    algan_startup = {name for name in startup if name.startswith("ALGAN_")}
+    assert algan_startup <= ALGAN_ENVIRONMENT_VARIABLES
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("1", True), ("TRUE", True), (" yes ", True), ("0", False), ("off", False)],
+)
+def test_env_flag_parses_both_spellings(monkeypatch, value, expected):
+    monkeypatch.setenv("ALGAN_HYBRID_RASTER", value)
+    assert env_flag("ALGAN_HYBRID_RASTER", not expected) is expected
+
+
+def test_env_accessors_fall_back_to_the_default(monkeypatch):
+    monkeypatch.delenv("ALGAN_KBUF", raising=False)
+    assert env_int("ALGAN_KBUF", 4) == 4
+    assert not env_is_set("ALGAN_KBUF")
+
+    monkeypatch.setenv("ALGAN_KBUF", "")
+    assert env_int("ALGAN_KBUF", 4) == 4
+    assert env_is_set("ALGAN_KBUF")
+
+    monkeypatch.setenv("ALGAN_KBUF", "8")
+    assert env_int("ALGAN_KBUF", 4) == 8
+
+
+@pytest.mark.parametrize(
+    ("accessor", "default"),
+    [(env_flag, False), (env_int, 4), (env_float, 1.5)],
+)
+def test_unusable_values_warn_and_keep_the_default(monkeypatch, accessor, default):
+    monkeypatch.setenv("ALGAN_KBUF", "nonsense")
+    with pytest.warns(AlganWarning, match="ALGAN_KBUF='nonsense' is not"):
+        assert accessor("ALGAN_KBUF", default) == default
+
+
+def test_env_str_returns_the_value_unstripped(monkeypatch):
+    monkeypatch.setenv("ALGAN_BVH_BUILD", " morton ")
+    assert env_str("ALGAN_BVH_BUILD", "split") == " morton "
+    monkeypatch.delenv("ALGAN_BVH_BUILD")
+    assert env_str("ALGAN_BVH_BUILD", "split") == "split"
+    assert env_str("ALGAN_BVH_BUILD") == ""
 
 
 def test_unknown_algan_environment_variables_are_sorted_and_warned():
@@ -65,6 +217,18 @@ def test_all_registered_algan_environment_variables_are_accepted():
         warnings.simplefilter("always")
         warn_for_unknown_algan_environment_variables(environ)
     assert not caught
+
+
+def test_harness_variables_are_accepted():
+    """Set by the test/bench harnesses, so exporting one must not warn."""
+    assert not unknown_algan_environment_variables(
+        {
+            "ALGAN_RUN_DOC_RENDERS": "1",
+            "ALGAN_RUN_FULL_RENDERS": "1",
+            "ALGAN_UPDATE_FAST_BASELINE": "1",
+            "ALGAN_UPDATE_FULL_RENDER_BASELINES": "1",
+        }
+    )
 
 
 @pytest.mark.slow

--- a/tests/unit_tests/test_environment.py
+++ b/tests/unit_tests/test_environment.py
@@ -47,7 +47,9 @@ def _is_environ_access(node):
 
 
 def _is_environ_subscript_write(statement):
-    targets = getattr(statement, "targets", None) or [getattr(statement, "target", None)]
+    targets = getattr(statement, "targets", None) or [
+        getattr(statement, "target", None)
+    ]
     return any(
         isinstance(target, ast.Subscript) and _is_environ_access(target.value)
         for target in targets


### PR DESCRIPTION
Refactor environment variable access throughout the codebase to use a new set of typed accessor functions (`env_flag`, `env_int`, `env_float`, `env_str`, `env_is_set`, `env_overrides`) instead of direct `os.environ` reads. This ensures all environment variable access is declared and validated at the point of use.

## Summary

The environment variable system has been redesigned to prevent silent failures from misspelled variable names. Instead of a passive registry that could drift from actual usage, every read now goes through accessor functions that validate the variable name against a declared set. This makes it impossible to add a new environment-controlled option without declaring it first.

## Key Changes

- **New accessor functions in `algan/environment.py`:**
  - `env_flag()` — parse boolean values (1/true/yes/on, 0/false/no/off)
  - `env_int()` — parse integer values
  - `env_float()` — parse float values
  - `env_str()` — return raw string value (unstripped)
  - `env_is_set()` — check if variable is present
  - `env_overrides()` — build environment dict for child processes
  - `startup_environment_variables()` — get the list of initialization-time variables

- **Reorganized variable declarations** into three categories:
  - `_STARTUP_VARIABLES` — consumed during Torch/Taichi initialization
  - `_HARNESS_VARIABLES` — used by test/benchmark harnesses
  - `_RUNTIME_VARIABLES` — read at module import or point of use

- **Validation enforcement:** All accessors call `_require_declared()` to reject undeclared names with `AlganConfigurationError`, making it impossible to silently misspell a variable name.

- **Lenient parsing:** Unusable values warn and fall back to the caller's default rather than aborting, so a mistyped tuning knob does not crash a render.

- **Updated all package code** to use the new accessors instead of direct `os.environ` reads:
  - `algan/rendering/raytracing/settings.py`
  - `algan/daemon_client.py`
  - `algan/settings/_startup.py`
  - `algan/rendering/taichi_runtime.py`
  - `algan/utils/profiling_utils.py`
  - `algan/rendering/raytracing/stbvh.py`
  - `algan/render_loop.py`
  - `algan/logging/logger.py`
  - `algan/rendering/raytracing/primitives.py`
  - `algan/rendering/raytracing/raytrace_kernels_taichi.py`
  - `algan/utils/taichi_warmstart.py`
  - `algan/utils/taichi_fast_launch.py`
  - `algan/animation_timeline/timeline.py`
  - `algan/rendering/post_processing/bloom.py`
  - `algan/rendering/raytracing/raster_pipeline.py`
  - `algan/rendering/raytracing/shading_taichi.py`
  - `algan/utils/manim_svg_cache.py`

- **Enhanced test coverage** in `tests/unit_tests/test_environment.py`:
  - New AST-based test that enforces all `ALGAN_` reads go through the accessors
  - Tests for undeclared name rejection
  - Tests for boolean/integer/float parsing with various formats
  - Tests for fallback to defaults and warning on unusable values
  - Tests for harness variables acceptance

## Implementation Details

- The registry is now the single source of truth: code reads *through* the accessors, not around them, so a knob added without a declaration raises on its first read instead of quietly becoming a variable users can misspell.

- `STARTUP_ENV` in `algan/daemon_client.py` is now derived from `startup_environment_variables()` rather than duplicated, keeping the two in sync automatically.

- The test suite includes an AST-based validator that scans all package code to ensure no

https://claude.ai/code/session_01VMjn1wHdEgRsVa8iJucBnT