### PR TITLE
Make the tessellation cache render-neutral

### DIFF
--- a/algan/mobs/triangulated_bezier_circuit.py
+++ b/algan/mobs/triangulated_bezier_circuit.py
@@ -822,6 +822,32 @@ def project_onto_line(params, point, invert=False):
     )
 
 
+#: Bumped whenever a change makes stored tessellations disagree with what a
+#: fresh one would produce. Entries written by an older Algan then miss rather
+#: than replay at a different origin, and are re-tessellated (and re-saved) on
+#: first use; the orphans age out with the rest of the cache directory.
+_TESSELLATION_CACHE_VERSION = "tessellation-v2-origin"
+
+
+def _tile_origin(offset):
+    """The point tile coordinates are stored relative to.
+
+    Cached tiles are position-independent -- the cache key is the glyph's
+    outline normalised to its own origin, so one entry serves that glyph
+    wherever it is placed -- which means they are stored as an offset from
+    something. That something has to be the *same* quantity on both sides of
+    the round trip: normalising by the tessellation's own minimum and adding
+    back the outline's minimum translates the glyph by whatever separates
+    them.
+    """
+    return offset.float()[:2]
+
+
+def _denormalize_tiles(tiles, offset):
+    """Put stored (origin-relative) tile coordinates back where they belong."""
+    return tiles + _tile_origin(offset)
+
+
 class TriangulatedBezierCircuit(Mob):
     def __init__(
         self,
@@ -878,6 +904,7 @@ class TriangulatedBezierCircuit(Mob):
                 hash_bytes = "".join([str(_.item()) for _ in hash_bytes.cpu()])
 
                 hasher = hashlib.sha256()
+                hasher.update(_TESSELLATION_CACHE_VERSION.encode())
                 hasher.update(hash_bytes.encode())
                 hash_bytes = hasher.hexdigest()[:32]
                 file_path = os.path.join(
@@ -889,7 +916,7 @@ class TriangulatedBezierCircuit(Mob):
                     tiles, tile_counts = torch.load(
                         file_path, map_location=_ANIMATION_DEVICE
                     )
-                    tiles = tiles + offset.float()[:2]
+                    tiles = _denormalize_tiles(tiles, offset)
                     found_hash = True
 
             points = []
@@ -924,10 +951,12 @@ class TriangulatedBezierCircuit(Mob):
                     continue
                 if hash_key is not None:
                     Path(file_path).parent.mkdir(parents=True, exist_ok=True)
-                    torch.save(
-                        (tiles - tiles.amin((0, 1), keepdim=True), tile_counts),
-                        file_path,
-                    )
+                    normalized = tiles - _tile_origin(offset)
+                    torch.save((normalized, tile_counts), file_path)
+                    # Replay the round-trip every later run gets off the cache,
+                    # so a freshly tessellated glyph and a cached one are the
+                    # same bits rather than the same to within float32 rounding.
+                    tiles = _denormalize_tiles(normalized, offset)
 
             tile_sizes, tile_grid_id, grid_width, grid_height = tile_counts
 

--- a/tests/unit_tests/test_tessellation_cache.py
+++ b/tests/unit_tests/test_tessellation_cache.py
@@ -1,0 +1,123 @@
+"""Render-neutrality of the on-disk tessellation cache.
+
+Cached tile geometry is stored relative to an origin so that one entry serves
+a glyph wherever it is placed. That normalisation has to be invisible: a mob
+built while the cache is cold and the same mob rebuilt from the cache must be
+the *same bits*, not merely close. They were not, and the gap was visible in a
+render -- 336 pixels of one ``text_and_media`` frame moved by up to 18 channel
+values, against the render suites' tolerance of 2 -- because analytic-AA edge
+coverage turns a few ULPs of vertex position into whole channel values wherever
+a coverage sample flips side of an edge.
+
+Two things went wrong, and this module guards both: the cold path skipped the
+round trip its own cache file would later impose, and the origin subtracted on
+save was not the origin added back on load.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+import torch
+
+from algan import TexTriangulated, TextTriangulated
+from algan.mobs import triangulated_bezier_circuit as tbc
+from algan.settings import SETTINGS
+
+
+@pytest.fixture
+def isolated_tessellation_cache(tmp_path):
+    """Point the tessellation cache at an empty directory for one test."""
+    saved = SETTINGS.paths.cache_directory
+    SETTINGS.paths.set(cache_directory=str(tmp_path))
+    try:
+        yield tmp_path / "tessellations"
+    finally:
+        SETTINGS.paths.set(cache_directory=saved)
+
+
+def _tiles_for(make_mob, monkeypatch):
+    """Every tile array ``make_mob()`` feeds into the packing stage.
+
+    ``packed_reorder`` is where the cold and cached paths converge, so it sees
+    exactly the geometry each path hands downstream.
+    """
+    captured = []
+    original = tbc.packed_reorder
+
+    def spy(tiles, *args, **kwargs):
+        captured.append(tiles.detach().cpu().clone())
+        return original(tiles, *args, **kwargs)
+
+    monkeypatch.setattr(tbc, "packed_reorder", spy)
+    make_mob()
+    monkeypatch.undo()
+    return captured
+
+
+@pytest.mark.parametrize(
+    "make_mob",
+    [
+        pytest.param(lambda: TextTriangulated("mesh", font_size=38), id="text"),
+        pytest.param(lambda: TexTriangulated(r"\alpha\beta", font_size=38), id="tex"),
+    ],
+)
+def test_cached_tessellation_is_bit_identical_to_a_fresh_one(
+    isolated_tessellation_cache, monkeypatch, make_mob
+):
+    cold = _tiles_for(make_mob, monkeypatch)
+    assert cold, "the mob tessellated nothing, so this proves nothing"
+    assert isolated_tessellation_cache.is_dir(), "the tessellation was not cached"
+
+    warm = _tiles_for(make_mob, monkeypatch)
+
+    assert len(warm) == len(cold)
+    for index, (fresh, cached) in enumerate(zip(cold, warm)):
+        assert torch.equal(cached, fresh), (
+            f"piece {index} came back from the cache with different geometry: "
+            f"max |delta| {(cached - fresh).abs().max().item():.3e}"
+        )
+
+
+def test_a_stale_entry_is_re_tessellated_rather_than_replayed(
+    isolated_tessellation_cache, monkeypatch
+):
+    """Cache files are keyed by a version tag, so an old layout cannot be read.
+
+    Entries written before the origin fix decode at a slightly different
+    position. They have to miss, not replay.
+    """
+    make_mob = lambda: TextTriangulated("mesh", font_size=38)  # noqa: E731
+    fresh = _tiles_for(make_mob, monkeypatch)
+    entries = sorted(isolated_tessellation_cache.glob("*.txt"))
+    assert entries, "nothing was cached"
+
+    monkeypatch.setattr(tbc, "_TESSELLATION_CACHE_VERSION", "tessellation-v1-legacy")
+    under_old_version = _tiles_for(make_mob, monkeypatch)
+
+    # A different version means different keys: the old files are untouched and
+    # the mob re-tessellates to the same geometry rather than reading them.
+    assert sorted(isolated_tessellation_cache.glob("*.txt")) != entries
+    for old, new in zip(fresh, under_old_version):
+        assert torch.equal(old, new)
+
+
+def test_normalisation_round_trip_uses_one_origin():
+    """The save and load sides must agree on what tiles are relative to."""
+    tiles = torch.tensor([[[3.5, -1.25], [4.0, 2.5]]])
+    offset = torch.tensor([1.5, -0.5, 9.0])  # third component is ignored
+
+    normalized = tiles - tbc._tile_origin(offset)
+    assert torch.equal(tbc._denormalize_tiles(normalized, offset), tiles)
+
+
+def test_cache_survives_a_wipe_between_builds(isolated_tessellation_cache, monkeypatch):
+    """Deleting the cache directory mid-session re-tessellates identically."""
+    make_mob = lambda: TextTriangulated("mesh", font_size=38)  # noqa: E731
+    first = _tiles_for(make_mob, monkeypatch)
+    shutil.rmtree(isolated_tessellation_cache)
+    second = _tiles_for(make_mob, monkeypatch)
+
+    for before, after in zip(first, second):
+        assert torch.equal(before, after)


### PR DESCRIPTION
A scene with triangulated glyphs rendered differently depending on whether `tessellations/` in the cache directory happened to be populated. Measured on `text_and_media`: 336 pixels of frame 23 (0.12% of the frame) differ by up to **18 channel values** against the render suites' tolerance of 2, all inside the 32x24 box holding `TextTriangulated` / `TexTriangulated`.

That means a `full_renders` baseline silently depended on cache state when it was generated — a trap for anyone re-baselining.

## Root cause

Two defects, both in the origin the cache normalizes against. Cached tiles are stored relative to an origin so one entry serves a glyph wherever it is placed, so they are always stored as an offset from *something*.

1. **The cold path skipped its own round trip.** It saved `tiles - tiles.amin(...)` and then went on using the absolute `tiles` it already had, while a cache hit reconstructed them as stored + offset. Subtract-then-add in float32 does not return the original bits — measured at ~1.5e-8 per coordinate — and analytic-AA edge coverage amplifies that to whole channel values wherever a coverage sample flips side of an edge. Same class as the `pn_criterion_kernel` borderline flips already documented in `CLAUDE.md`.

2. **The two sides used different origins.** Save subtracted the tessellation's own minimum; load added back the outline's minimum. They agree to ~2e-9 for the glyphs measured, but nothing makes them equal — a glyph whose control-point bounds differ from its tessellated bounds would come back *translated*, not merely epsilon-shifted.

The cold path now replays the same round trip, and both sides go through a shared `_tile_origin`. Cache keys carry a version tag, so entries written at the old origin miss and are re-tessellated rather than replayed at the wrong position.

## Verification

- Tessellation geometry is bit-identical cold vs warm for both `TextTriangulated` and `TexTriangulated` (compared at `packed_reorder`, where the two paths converge).
- End-to-end, **all six full-render scenes are byte-identical between a cold cache and a warm one**.
- The fix is **cold-preserving**: the post-fix render is byte-identical to the pre-fix *cold* render across all 182 frames of `text_and_media`. Both paths now land on the freshly-computed value.
- The new regression tests fail on the un-fixed code, reporting the original 1.49e-08.
- Fast suite green, 73s of its 150s budget (the new tests add ~8s).

## Baselines

No baselines are regenerated here, and the fix being cold-preserving is why: a baseline generated with a cold cache does not move at all, and every scene that passed on this machine still passes.

The only candidates are `shapes_and_timeline` and `text_and_media`, and they cannot be evaluated on a cloud session — both already miss the committed baselines by 189–200 channel values from the per-machine `fast_math` divergence described in `CLAUDE.md`. Regenerating them there would overwrite the CPU set with that divergence, an error an order of magnitude larger than the effect being fixed and unrelated to it.

**On a machine whose baselines these are:** run `tests/full_renders`. If those two scenes still pass, the baselines were generated cold and nothing needs regenerating. If they move by <=18 channel values localized to the triangulated-glyph regions, that is this fix correcting a warm-cache baseline — re-baseline CPU and CUDA deliberately.

## Not verified

The cold path now combines `tiles` with `offset`, two tensors the warm path already mixed successfully, so device placement should be equivalent — but that reasoning is from the code, not from a CUDA run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMjn1wHdEgRsVa8iJucBnT

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMjn1wHdEgRsVa8iJucBnT)_