### PR TITLE
Wrap a closed surface's texture at its seam instead of clamping

### DIFF
--- a/algan/mobs/surfaces/surface.py
+++ b/algan/mobs/surfaces/surface.py
@@ -354,6 +354,75 @@ def surface_weld_flags(grid):
     return (wrap_x, pole_lo, pole_hi)
 
 
+def surface_closed_axes(grid):
+    """Which parameter axes of a materialized grid close on themselves.
+
+    Returns ``(closed_u, closed_v)``: ``closed_u`` when column ``W-1``
+    coincides with column 0 (a surface of revolution's u-seam -- a
+    :class:`~.Sphere`, a :class:`~.Cylinder`, a :class:`~.Cone`), ``closed_v``
+    when row ``H-1`` coincides with row 0 (a :class:`~.Torus` closes on both).
+
+    This is :func:`surface_weld_flags`'s ``wrap_x`` test on both axes, but it
+    answers a different question -- how a *texture* must be sampled, not how
+    triangles are indexed -- so it is deliberately not gated on
+    ``ALGAN_WELD_SURFACE_SEAMS``: a closed surface's texture has to wrap
+    whether or not its seam vertices are shared.
+
+    Returns Python bools, so this synchronises with the device once per
+    textured primitive build. The result changes a tensor's *shape* (see
+    :func:`wrap_pad_texture`), which a device value cannot do.
+    """
+    if grid.dim() < 3:
+        return (False, False)
+    tol = _WELD_TOLERANCE
+    # A single-sample axis has one column playing both edges, which the test
+    # below cannot tell from a wraparound.
+    closed_u = grid.shape[-3] > 1 and bool(
+        (grid[..., 0, :, :] - grid[..., -1, :, :]).abs().lt(tol).all().item()
+    )
+    closed_v = grid.shape[-2] > 1 and bool(
+        (grid[..., :, 0, :] - grid[..., :, -1, :]).abs().lt(tol).all().item()
+    )
+    return (closed_u, closed_v)
+
+
+def wrap_pad_texture(texture, closed_axes):
+    """Repeat a texture's first row/column at its far edge on closed axes.
+
+    The renderer addresses a ``[W, H]`` map as ``u * (W - 1)`` and clamps, so
+    texel 0 sits at ``u == 0`` and texel ``W-1`` at ``u == 1``. On a surface
+    whose u axis closes those are the *same place*, and the sampler has no way
+    to blend the last texel back into the first: the map lands on the surface
+    stretched by ``W / (W - 1)`` and cut by a hard seam wherever column 0
+    disagrees with column ``W-1``.
+
+    Appending a copy of column 0 as column ``W`` fixes both at once. Texel
+    ``i`` then sits at ``u == i / W``, so every column spans the same
+    ``1 / W`` of the way around, and the wrap cell interpolates column ``W-1``
+    into column 0 exactly as an interior cell interpolates its neighbours.
+
+    Parameters
+    ----------
+    texture
+        A texture map ``[T, W, H, C]`` (u along ``W``, v along ``H``), or None.
+    closed_axes
+        ``(closed_u, closed_v)`` from :func:`surface_closed_axes`.
+
+    Returns
+    -------
+    torch.Tensor
+        The padded map, or ``texture`` unchanged when neither axis closes.
+    """
+    if texture is None:
+        return None
+    closed_u, closed_v = closed_axes
+    if closed_u and texture.shape[-3] > 1:
+        texture = torch.cat((texture, texture[..., :1, :, :]), -3)
+    if closed_v and texture.shape[-2] > 1:
+        texture = torch.cat((texture, texture[..., :, :1, :]), -2)
+    return texture
+
+
 def grid_to_triangle_vertices(grid, weld=(False, False, False)):
     """Internal: gather a per-grid-point quantity into per-triangle-vertex form.
 
@@ -1098,6 +1167,13 @@ class Surface(Mob):
         the surface as it deforms. ``None`` means the surface is drawn from its
         per-vertex colours instead. Assigning a texture whose resolution differs from
         the current one detaches history, since the two cannot be interpolated.
+
+        On an axis where the surface closes on itself -- ``u`` on a
+        :class:`~algan.mobs.shapes_3d.Sphere`, both axes on a
+        :class:`~algan.mobs.shapes_3d.Torus` -- the image wraps: its last column of
+        texels neighbours its first, each column spanning ``1 / W`` of the way
+        around, so a map whose edges join draws no seam. On an open axis the first
+        and last texels sit on the two edges.
 
         Animation
         ---------
@@ -2662,6 +2738,13 @@ class Surface(Mob):
         batch sizer prices a 1774x887 image at a few kilobytes per frame and
         puts an entire video in a single batch.
 
+        A closed surface's map is wrap-padded (:func:`wrap_pad_texture`) on its
+        way to the renderer, which is a third copy, live while the premultiply
+        clones off it. Whether a surface closes is a property of its animated
+        geometry, so it is read off the previous primitive build -- the first
+        batch of a job prices a globe as if it were a plane, and the
+        out-of-render-memory retry is what covers that.
+
         Rows orphaned by :meth:`~algan.animatable_base.mob.Mob.detach_history`
         are materialized too but belong to no live Mob, so they are not
         attributed here; the animation memory fraction absorbs them.
@@ -2678,7 +2761,8 @@ class Surface(Mob):
         inds = None if timeline is None else timeline.mob_id_to_inds.get(self.id)
         rows = 1 if inds is None else int(inds.numel())
         texels = int(self.texture_height) * int(self.texture_width) * 5
-        return rows * texels * 4 * 2
+        copies = 3 if getattr(self, "_texture_is_wrap_padded", False) else 2
+        return rows * texels * 4 * copies
 
     def _packed_grid_count(self):
         """Number of independent grids concatenated into ``self.grid``.
@@ -2787,6 +2871,7 @@ class Surface(Mob):
 
         uvs = None
         texture_map = None
+        closed_axes = (False, False)
         material_texture_map = getattr(self, "material_texture", None)
         material_texture_flags = getattr(self, "material_texture_flags", 0)
         normal_texture_map = getattr(self, "normal_texture", None)
@@ -2810,17 +2895,29 @@ class Surface(Mob):
             if packed_grid_count is not None:
                 uvs = uvs.unsqueeze(0).expand(packed_grid_count, -1, -1).flatten(0, 1)
             uvs = uvs.unsqueeze(0)  # [1, num_triangles * 3, 2]
+            # u = 0 and u = 1 are the same place on a closed surface, so every
+            # map sampled against these uvs has to wrap there rather than
+            # clamp. wrap_pad_texture makes the clamping sampler do that.
+            closed_axes = surface_closed_axes(grid)
+            self._texture_is_wrap_padded = any(closed_axes)
+            material_texture_map = wrap_pad_texture(material_texture_map, closed_axes)
+            normal_texture_map = wrap_pad_texture(normal_texture_map, closed_axes)
         if has_color_texture:
             # Read the texels once, uncopied: this is the widest attribute in
             # the engine, and mult_opacity is out-of-place (Color.prep_set
             # clones), so the materialized state is never written through.
+            # Pad as a plain tensor, before mult_opacity, so the cat stays off
+            # Color's __torch_function__.
             texels = self._color_texture_uncopied()
             texture_map = (
-                texels.view(
-                    texels.shape[0],
-                    self.texture_height,
-                    self.texture_width,
-                    5,
+                wrap_pad_texture(
+                    texels.view(
+                        texels.shape[0],
+                        self.texture_height,
+                        self.texture_width,
+                        5,
+                    ),
+                    closed_axes,
                 )
                 .as_subclass(Color)
                 .mult_opacity(self.opacity.unsqueeze(-2))

--- a/algan/rendering/raytracing/DESIGN_mesh_identity.md
+++ b/algan/rendering/raytracing/DESIGN_mesh_identity.md
@@ -330,6 +330,15 @@ deliberately does not. Wrapping it would give the last cell column `u = 0` where
 the texture needs `u = 1`, running the map backwards across that column. The
 duplicate uv column exists precisely to carry that discontinuity.
 
+The *texture* is what has to be continuous across it, and that is a separate
+mechanism with a separate predicate. `surface_closed_axes` (`surface.py`) runs
+the same coincidence test on both axes, ungated — a closed surface's map wraps
+whether or not its seam vertices are shared — and `wrap_pad_texture` repeats
+column 0 at column `W`, so the sampler's `u * (W - 1)` clamp addresses a padded
+`W + 1` columns and interpolates the wrap cell exactly as it does an interior
+one. Both are needed: the uv column carries `u = 1` to the seam, the pad gives
+`u = 1` the same texels as `u = 0`.
+
 3.2 Watertight ray/triangle intersection  [LANDED, gated off]
 ------------------------------------------------------------------
 With seams welded and interior edges bit-identical, a watertight test

--- a/docs/source/advanced_user_tutorials/images_and_textures.rst
+++ b/docs/source/advanced_user_tutorials/images_and_textures.rst
@@ -150,6 +150,27 @@ inside the ray tracing kernel**, for both flat and curved (PN) triangles. A prop
 without a map keeps the ordinary per-vertex value, and maps of different resolutions
 are resampled to a common one.
 
+Wrapping around a closed surface
+--------------------------------
+
+On a surface that closes on itself -- a :class:`~.Sphere`, a :class:`~.Cylinder`
+and a :class:`~.Cone` close around ``u``, a :class:`~.Torus` around both -- the
+map **wraps**: the last column of texels is a neighbour of the first, and Algan
+blends across that meridian the same way it blends anywhere else. So the
+checkerboard above meets itself where the sphere comes back around, and a map
+whose two edges are meant to join (an equirectangular world map, a tiling
+pattern) joins seamlessly.
+
+Each texel column therefore spans exactly ``1 / W`` of the way around, not
+``1 / (W - 1)``: with a 16-wide map, column 0 is centred at the seam and column
+8 faces the other side, whichever direction the surface is spun. Algan works out
+which axes close from the geometry, so a surface of your own written with
+:class:`~.Surface` and a ``coord_function`` wraps too, without saying so.
+
+An **open** surface -- a flat plane, an :class:`~.ImageMob`, the pole-to-pole
+``v`` axis of a sphere -- has no far side to blend into, so its first and last
+texels sit exactly on its two edges and the edge value carries beyond them.
+
 Animating a texture
 -------------------
 
@@ -188,6 +209,11 @@ Glow maps
 ``glow_texture`` is the exception to the per-fragment rule: glow is consumed by the
 glow accumulator per *vertex*, so the map is baked down to the surface grid
 resolution. Raise ``grid_width`` / ``grid_height`` if you need more detail from it.
+
+That bake is also the exception to the wrapping above -- it lands the map's two
+edges on the same grid column of a closed surface, so a glow map whose edges do
+not already agree shows its seam. Make the first and last column of a
+``glow_texture`` match if you need it to wrap.
 
 Colouring a 2-D Shape
 =====================

--- a/tests/unit_tests/test_texture_seam_wrapping.py
+++ b/tests/unit_tests/test_texture_seam_wrapping.py
@@ -1,0 +1,210 @@
+"""A closed surface's texture has to wrap at its seam, not clamp.
+
+The renderer addresses a ``[W, H]`` map as ``u * (W - 1)`` and clamps (see
+``_sample_texture`` in ``raytrace_kernels_taichi.py`` and ``_sample_tex_vec5``
+in ``wavefront_kernels_taichi.py``), so texel 0 sits at ``u == 0`` and texel
+``W-1`` at ``u == 1``. On a :class:`~.Sphere` those are the same meridian, so
+the map arrived stretched by ``W / (W - 1)`` and cut by a hard seam wherever
+column 0 disagreed with column ``W-1``.
+
+:func:`wrap_pad_texture` repeats column 0 at column ``W``, which puts texel
+``i`` at ``u == i / W`` and lets the clamping sampler interpolate across the
+seam. These tests pin the padding, the closure predicate that selects it, and
+the sampling identity that makes it the right amount of padding -- with a
+reference implementation of the kernel's own addressing, because that
+convention is what the padding is calibrated against.
+
+Feature tests for the texture path: unmarked, so outside the fast suite.
+"""
+
+import torch
+
+from algan.mobs.shapes_3d import Cylinder, Sphere, Torus
+from algan.mobs.surfaces.surface import (
+    Surface,
+    surface_closed_axes,
+    wrap_pad_texture,
+)
+from algan.scene_manager import SceneManager
+
+
+def _checker(width, height):
+    """A ``[W, H, 5]`` checkerboard, opaque, red/blue by parity."""
+    texture = torch.zeros(width, height, 5)
+    parity = (torch.arange(width).view(-1, 1) + torch.arange(height).view(1, -1)) % 2
+    texture[..., 0] = parity
+    texture[..., 2] = 1 - parity
+    texture[..., 4] = 1.0
+    return texture
+
+
+def _sample(texture, u, v):
+    """The renderer's own bilinear texel addressing, in plain torch.
+
+    Mirrors ``_sample_texture``: ``u`` addresses the first axis as
+    ``u * (W - 1)``, ``v`` the second as ``v * (H - 1)``, both clamped, then a
+    bilinear blend of the four surrounding texels.
+    """
+    width, height = texture.shape[-3], texture.shape[-2]
+    px = min(max(u * (width - 1), 0.0), width - 1.0)
+    py = min(max(v * (height - 1), 0.0), height - 1.0)
+    x0, y0 = int(px), int(py)
+    x1, y1 = min(x0 + 1, width - 1), min(y0 + 1, height - 1)
+    xr, yr = px - x0, py - y0
+    return (
+        texture[x0, y0] * (1 - xr) * (1 - yr)
+        + texture[x1, y0] * xr * (1 - yr)
+        + texture[x0, y1] * (1 - xr) * yr
+        + texture[x1, y1] * xr * yr
+    )
+
+
+def test_a_sphere_grid_closes_on_u_and_a_plane_closes_on_neither():
+    SceneManager.reset()
+    sphere = Sphere(radius=1.5)
+    assert surface_closed_axes(
+        sphere._reshape_grid_for_render(sphere.grid.location)
+    ) == (True, False), "a sphere's u wraps a full turn; its v runs pole to pole"
+
+    plane = Surface(grid_width=6, grid_height=6)
+    assert surface_closed_axes(plane._reshape_grid_for_render(plane.grid.location)) == (
+        False,
+        False,
+    ), "a flat plane closes on neither axis"
+
+
+def test_a_torus_closes_on_both_axes_and_a_cylinder_only_on_u():
+    SceneManager.reset()
+    torus = Torus()
+    assert surface_closed_axes(torus._reshape_grid_for_render(torus.grid.location)) == (
+        True,
+        True,
+    )
+
+    cylinder = Cylinder(radius=1, height=2)
+    assert surface_closed_axes(
+        cylinder._reshape_grid_for_render(cylinder.grid.location)
+    ) == (True, False), "a cylinder's two rim rows sit at different heights"
+
+
+def test_a_single_sample_axis_is_not_mistaken_for_a_wraparound():
+    """One column is its own first and last, which the coincidence test cannot
+    distinguish from a surface that closes.
+    """
+    # W = 1: four distinct samples along v, one column along u.
+    line = torch.arange(4.0).view(1, 4, 1).expand(1, 4, 3)
+    assert surface_closed_axes(line) == (False, False)
+
+
+def test_padding_repeats_the_first_row_or_column_of_a_closed_axis():
+    texture = _checker(8, 6).unsqueeze(0)
+
+    padded_u = wrap_pad_texture(texture, (True, False))
+    assert padded_u.shape == (1, 9, 6, 5)
+    assert torch.equal(padded_u[:, :8], texture), "the original texels must survive"
+    assert torch.equal(padded_u[:, 8], texture[:, 0]), "column W must repeat column 0"
+
+    padded_both = wrap_pad_texture(texture, (True, True))
+    assert padded_both.shape == (1, 9, 7, 5)
+    assert torch.equal(padded_both[:, :, 6], padded_both[:, :, 0])
+
+
+def test_an_open_surface_keeps_the_very_tensor_it_was_given():
+    """Not merely equal: unchanged, so nothing textured that does not close
+    pays a copy or moves a pixel.
+    """
+    texture = _checker(8, 6).unsqueeze(0)
+    assert wrap_pad_texture(texture, (False, False)) is texture
+    assert wrap_pad_texture(None, (True, True)) is None
+
+
+def test_padding_puts_every_texel_an_equal_step_apart_around_the_seam():
+    """The point of one extra column: ``u = 0`` and ``u = 1`` land on one texel.
+
+    Texel ``i`` of a padded W-column map sits at ``u == i / W``, so the wrap
+    cell spans the same ``1 / W`` as every interior cell -- which is what makes
+    the pattern continuous where the surface closes.
+    """
+    width = 8
+    # v = 0.5 of a 5-row map addresses row 2 exactly, so nothing below blends
+    # two rows and hides a column difference behind their average.
+    padded = wrap_pad_texture(_checker(width, 5), (True, False))
+
+    assert torch.equal(_sample(padded, 0.0, 0.5), _sample(padded, 1.0, 0.5)), (
+        "u = 0 and u = 1 are the same meridian and must sample the same colour"
+    )
+    for i in range(width):
+        assert torch.equal(_sample(padded, i / width, 0.5), padded[i, 2]), (
+            f"texel {i} should land exactly on u = {i}/{width}"
+        )
+    # Halfway across the wrap cell blends the last column into the first, the
+    # same blend an interior cell gets.
+    seam = _sample(padded, (width - 0.5) / width, 0.5)
+    interior = _sample(padded, (width - 1.5) / width, 0.5)
+    assert torch.allclose(seam, (padded[width - 1, 2] + padded[0, 2]) / 2)
+    assert torch.allclose(interior, (padded[width - 2, 2] + padded[width - 1, 2]) / 2)
+
+
+def test_an_unpadded_map_would_seam_a_sphere():
+    """The bug this fixes, stated as a measurement on the old addressing."""
+    width = 8
+    unpadded = _checker(width, 5)
+    left = _sample(unpadded, 0.0, 0.5)
+    right = _sample(unpadded, 1.0, 0.5)
+    assert not torch.equal(left, right), (
+        "column 0 and column W-1 differ, and both sat on the seam meridian"
+    )
+
+
+def test_a_spheres_render_primitive_carries_a_wrapped_colour_map():
+    SceneManager.reset()
+    sphere = Sphere(radius=1.5, color_texture=_checker(8, 8)).spawn()
+    texture_map = sphere.get_render_primitives().texture_map
+
+    assert texture_map.shape[-3] == 9, "the u axis must gain its wrap column"
+    assert texture_map.shape[-2] == 8, "v runs pole to pole and must not wrap"
+    assert torch.equal(texture_map[..., 0, :, :], texture_map[..., -1, :, :])
+
+
+def test_a_planes_render_primitive_carries_the_map_unchanged():
+    SceneManager.reset()
+    plane = Surface(color_texture=_checker(8, 8), grid_width=6, grid_height=6).spawn()
+    texture_map = plane.get_render_primitives().texture_map
+
+    assert texture_map.shape[-3:] == (8, 8, 5)
+
+
+def test_material_and_normal_maps_wrap_with_the_colour_map():
+    """They are sampled against the same uvs, so they seam the same way."""
+    SceneManager.reset()
+    sphere = Sphere(
+        radius=1.5,
+        roughness_texture=torch.rand(8, 6, 1),
+        normal_texture=torch.rand(8, 6, 3),
+    ).spawn()
+    primitive = sphere.get_render_primitives()
+
+    assert primitive.material_texture_map.shape[-3:-1] == (9, 6)
+    assert torch.equal(
+        primitive.material_texture_map[..., 0, :, :],
+        primitive.material_texture_map[..., -1, :, :],
+    )
+    assert primitive.normal_texture_map.shape[-3:-1] == (9, 6)
+    assert torch.equal(
+        primitive.normal_texture_map[..., 0, :, :],
+        primitive.normal_texture_map[..., -1, :, :],
+    )
+
+
+def test_a_wrapped_surface_prices_its_extra_copy_into_the_batch_sizer():
+    """A colour texture dominates a textured surface's render memory, and the
+    wrap pad is one more live copy of it while the premultiply clones off it.
+    """
+    SceneManager.reset()
+    sphere = Sphere(radius=1.5, color_texture=_checker(32, 32)).spawn()
+
+    assert sphere._color_texture_bytes_per_timestep() == 32 * 32 * 5 * 4 * 2, (
+        "before a primitive build nothing knows the surface closes"
+    )
+    sphere.get_render_primitives()
+    assert sphere._color_texture_bytes_per_timestep() == 32 * 32 * 5 * 4 * 3


### PR DESCRIPTION
## What and why

A texture on a `Sphere` did not meet itself where the sphere came back around.
The images_and_textures tutorial's checkerboard globe shows it plainly: a hard
vertical line the pattern jumps across, visible whenever the seam meridian
faces the camera.

The renderer addresses a `[W, H]` map as `u * (W - 1)` and clamps, which puts
texel 0 at `u == 0` and texel `W-1` at `u == 1`. That is right for a flat
image, whose two edges are two different places. On a sphere they are the
*same meridian*, so the map arrived with two defects at once: stretched by
`W / (W - 1)`, and with its first and last columns stacked on the seam, where
clamping gives the sampler no way to blend one into the other. Small maps show
it as a jump; a 2048-wide world map hid it in a sub-pixel offset, which is why
it had gone unnoticed.

The fix is to repeat column 0 at column `W` on any axis where the
parametrization closes, and let the existing clamping sampler do the rest:
texel `i` then lands at `u == i / W`, every column spans the same `1 / W` of
the way around, and the wrap cell interpolates column `W-1` into column 0
exactly as an interior cell interpolates its neighbours. No kernel changed.

Which axes close is read off the geometry (`surface_closed_axes`, the
coincidence test `surface_weld_flags` already used, now run on both axes) — `u`
for a `Sphere`, `Cylinder` and `Cone`, both for a `Torus`, and a surface of
your own written with a `coord_function` gets it without declaring anything.
It is deliberately not gated on `ALGAN_WELD_SURFACE_SEAMS`: a texture has to
wrap whether or not the seam *vertices* are shared, and the two are separate
mechanisms — the duplicate uv column still carries `u = 1` to the seam, and the
pad is what gives `u = 1` the same texels as `u = 0`. Colour, material and
normal maps are sampled against those same uvs, so all three get it.

An open axis is untouched down to tensor identity, so a plane, an `ImageMob`
and a sphere's pole-to-pole `v` keep the addressing they had and cannot move a
pixel.

Two things left alone on purpose, both now stated in the tutorial:

- `glow_texture` is baked to grid vertices at construction, so it still lands
  both map edges on the same grid column of a closed surface. Fixing it needs a
  topology signal at construction time, which would go stale under
  `set_shape_to`.
- The batch sizer learns that a surface is wrap-padded from the previous
  primitive build, so the first batch of a textured-globe job prices the extra
  copy as if the surface were a plane and leans on the out-of-render-memory
  retry.

## Rendered output

**Unchanged in both render suites**, and not by assumption:
`pytest -q tests/full_renders` passes against the committed
`expected_outputs_cpu/` baselines on this machine, and `tests/fast` passes its
pixel comparison. Neither suite contains a closed surface carrying a texture
map — `tests/full_renders`' only textures are flat `ImageMob`s and a glTF model
(a `Mob`, not a `Surface`), and `tests/fast/scene.py` has none — so nothing was
regenerated and nothing needs to be, on either device.

Output does move for a closed textured surface, which is the point. Checked by
eye at four rotations each: the tutorial's 16×16 checkerboard globe (seam
gone), a `Torus` and a `Cylinder` (both continuous), and the world-map globe
from the reshaping example, whose 2048-wide map shifts by less than a pixel and
looks identical before and after.

## Verification

Run on this CPU-only cloud session (no GPU):

- `pytest -q tests/unit_tests tests/fast` — 1091 passed, 91 skipped. This is
  what CI runs.
- `pytest -q --fast` — 211 passed, 47s of its 75s budget.
- `pytest -q tests/full_renders` — 7 passed (it runs here; `CI` is unset).
- `ruff check --no-fix` and `ruff format --check` on the touched files — clean.
- `docs/make_and_open_docs.py --skip-examples --no-open` — build succeeded. The
  one warning is a missing `graphviz` binary in this container, present on a
  clean build of `master` too.

Not checked here: CUDA behaviour and any CPU/CUDA divergence, which this
machine cannot speak to. The change is device-independent tensor prep in the
primitive build with no kernel edit, so there is no `fast_math` or
tessellation-criterion path involved.

New tests in `tests/unit_tests/test_texture_seam_wrapping.py` (11, unmarked —
feature tests for the texture path). They pin the closure predicate on a
sphere, torus, cylinder and plane, the padding itself, and the sampling
identity that makes one column the right amount of padding — the last against a
plain-torch reference of the kernel's own texel addressing, so the padding
stays pinned to the convention it is calibrated against rather than to its own
shape.

## Docs

- `docs/source/advanced_user_tutorials/images_and_textures.rst` — a new
  "Wrapping around a closed surface" subsection under *Texturing Any Surface*,
  and a note under *Glow maps* that the per-vertex bake is the exception.
- `Surface.color_texture`'s docstring says what wrapping means for the image
  you assign.
- `algan/rendering/raytracing/DESIGN_mesh_identity.md` §3.1 — the UV-subtlety
  note now distinguishes the uv seam (unwelded, carries the discontinuity) from
  the texture wrap (padded, removes it).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSpe2G2td1DB1dboQ1GA89)_