### PR TITLE
Finish the docs audit: parametric ranges, text constructor docs, move_to_edge

### DIFF
--- a/DOCSTRINGS.md
+++ b/DOCSTRINGS.md
@@ -483,8 +483,10 @@ executed and rendered into Algan's own reference pages — on an Algan page; the
 Algan-authored docstring from `_WRAPPER_DOCSTRINGS` in `algan/mobs/manim_compat.py`. Two things
 turned up while writing them: `MarkupText` strips its markup unconditionally rather than only when
 Pango is missing (its docstring claimed otherwise), and a `Title` places itself against *Manim's*
-frame, so it renders clipped off the top of Algan's. Both are now stated where a reader will hit
-them.
+frame, which puts its top at exactly Algan's top border — flush against the edge with no margin.
+Reaching for `move_to_edge` to inset it pushes it further out instead, because that method takes
+its inset direction from `normalize(boundary - border)` and that is degenerate for a boundary
+already lying on the border. Both are now stated where a reader will hit them.
 
 Fix in this order, since it tracks what users hit first:
 

--- a/DOCSTRINGS.md
+++ b/DOCSTRINGS.md
@@ -484,9 +484,10 @@ Algan-authored docstring from `_WRAPPER_DOCSTRINGS` in `algan/mobs/manim_compat.
 turned up while writing them: `MarkupText` strips its markup unconditionally rather than only when
 Pango is missing (its docstring claimed otherwise), and a `Title` places itself against *Manim's*
 frame, which puts its top at exactly Algan's top border — flush against the edge with no margin.
-Reaching for `move_to_edge` to inset it pushes it further out instead, because that method takes
-its inset direction from `normalize(boundary - border)` and that is degenerate for a boundary
-already lying on the border. Both are now stated where a reader will hit them.
+Both are now stated where a reader will hit them. Chasing the second one turned up a real bug in
+`move_to_edge`, since fixed: it took its inset direction from `normalize(boundary - border)`, which
+is degenerate for a boundary lying on the border and points the wrong way for a Mob already
+off-screen.
 
 Fix in this order, since it tracks what users hit first:
 

--- a/DOCSTRINGS.md
+++ b/DOCSTRINGS.md
@@ -467,16 +467,24 @@ no docstring at all**, and nearly all of those are nested helper closures (`wrap
 is documented. Of the docstrings that exist, the most common remaining defect is an unstated
 default, followed by missing units and missing `Animation` semantics.
 
-Steps 1 and 2 below are done, and step 3's **shape** half is now done too: every 2-D and 3-D shape
-class in the gallery carries a `Parameters` section with defaults, units and an example, including
-the `u_range` / `v_range` domains §4.3 calls out. Documenting those turned up an API defect worth
-knowing about — `Sphere`'s `u_range`/`v_range` and `Cylinder`'s `v_range` are accepted and stored
-but never read by their `coord_function`, so a partial range silently builds a whole shape. The
-docstrings say so; the code is unchanged, because making them functional moves rendered output.
+Steps 1 and 2 below are done, and step 3 is now done in both halves. Every 2-D and 3-D shape class
+in the gallery carries a `Parameters` section with defaults, units and an example, including the
+`u_range` / `v_range` domains §4.3 calls out. Documenting those turned up an API defect —
+`Sphere`'s `u_range`/`v_range` and `Cylinder`'s `v_range` were accepted and stored but never read
+by their `coord_function`, so a partial range silently built a whole shape. That is fixed: the
+ranges are folded into the endpoints of the existing interpolation, so the default domains
+reproduce the previous vertices bit for bit and no baseline moved.
 
-The outstanding work in step 3 is the **text** constructors: `Tex`, `MathTex` and `Title` still
-put their constructor prose in `__init__` rather than the class docstring (§10) and none of the
-three has a `Parameters` section.
+The **text** constructors are done too. `Tex`'s constructor prose moved out of `__init__` into the
+class docstring (§10), and `Tex`, `Text` and `MarkupText` each document every parameter in their
+signature with its default. `MathTex` and `Title` are generated Manim-compatibility wrappers and
+used to inherit Manim's class docstring verbatim, which put a `.. manim::` block — a Manim scene,
+executed and rendered into Algan's own reference pages — on an Algan page; they now carry an
+Algan-authored docstring from `_WRAPPER_DOCSTRINGS` in `algan/mobs/manim_compat.py`. Two things
+turned up while writing them: `MarkupText` strips its markup unconditionally rather than only when
+Pango is missing (its docstring claimed otherwise), and a `Title` places itself against *Manim's*
+frame, so it renders clipped off the top of Algan's. Both are now stated where a reader will hit
+them.
 
 Fix in this order, since it tracks what users hit first:
 

--- a/algan/animatable_base/mob_movement.py
+++ b/algan/animatable_base/mob_movement.py
@@ -653,8 +653,11 @@ class MobMovementMixin:
     def move_to_edge(self, edge: torch.Tensor, buffer: float | None = None) -> Mob:
         """Move the Mob against one edge of the screen.
 
-        The Mob's own boundary is what comes to rest ``buffer`` from the border,
-        so a large and a small shape both end up looking equally inset.
+        The Mob's own boundary is what comes to rest ``buffer`` *inside* the
+        border, so a large and a small shape both end up looking equally inset.
+        Where the Mob starts makes no difference: one that is already off-screen
+        past that edge is brought back in, and calling this twice leaves it where
+        the first call put it.
 
         Animation
         ---------
@@ -692,12 +695,16 @@ class MobMovementMixin:
         edge_point_on_screen = self.scene.camera.project_point_onto_screen_border(
             mob_boundary_point, normalized_edge
         )
-        # Calculate the final target location for the Mob, accounting for the buffer
-        target_location = (
-            edge_point_on_screen
-            + F.normalize(mob_boundary_point - edge_point_on_screen, p=2, dim=-1)
-            * buffer
-        )
+        # Step back from the border along the edge direction. The inset used to
+        # be taken as ``normalize(boundary - border) * buffer``, which reads the
+        # direction off the Mob's current position instead of off the edge that
+        # was asked for. The border is cast *from* the boundary along the edge,
+        # so that difference is antiparallel to the edge whenever the Mob is
+        # inside the frame -- but it flips for a Mob already outside (leaving it
+        # ``buffer`` outside rather than bringing it in), and it degenerates to
+        # zero for a boundary resting exactly on the border, where float noise
+        # then chose the sign. A Manim ``Title`` lands exactly there.
+        target_location = edge_point_on_screen - normalized_edge * buffer
         # Calculate the displacement needed and move the Mob
         displacement = target_location - mob_boundary_point
         self.move(displacement)

--- a/algan/mobs/manim_compat.py
+++ b/algan/mobs/manim_compat.py
@@ -771,14 +771,20 @@ The text is typeset by LaTeX in text mode (so ``Title("Chapter 1")`` reads as
 written, no maths escaping needed) with a horizontal rule beneath it, and the
 whole thing is moved to the top of the frame.
 
-**The frame it moves to the top of is Manim's, not Algan's.** Manim's is 8 world
-units tall; Algan's default camera shows about 7, so a ``Title`` left where it
-puts itself is clipped along its top edge. Move it down about a unit, or scale
-it first. :meth:`~algan.animatable_base.mob_movement.MobMovementMixin.move_to_edge`
-is the obvious fix and is the wrong one -- a compatibility Mob's ``location`` is
-the centre of the backing Mobject's own points rather than of the composite, so
-on a ``Title`` (whose rule is a submobject) the edge is measured from the wrong
-place and the text ends up further off-screen, not closer.
+**The frame it moves to the top of is Manim's, not Algan's, and it lands flush
+against the edge.** Manim's frame is 8 world units tall and its ``to_edge``
+leaves a 0.5 gap, so the title's top comes to rest at ``y = 3.5`` -- which is
+exactly where Algan's default camera puts its top border. Nothing is cut off,
+but the text touches the frame edge with no margin at all. ``.move(DOWN * 1)``
+insets it.
+
+:meth:`~algan.animatable_base.mob_movement.MobMovementMixin.move_to_edge` is the
+obvious way to inset it and does the opposite -- it pushes the title ``buffer``
+further out. That is not a ``Title`` quirk: the method takes its inset direction
+from ``normalize(boundary - border)``, and for a Mob whose boundary already lies
+*on* the border that difference is zero, so float rounding decides the sign.
+Here it resolves outward. A Mob that starts clearly outside the frame is pulled
+back in correctly; it is landing exactly on the border that is degenerate.
 
 The default rule is sized from Manim's frame too, at ``frame_width - 2``, which
 comes out just narrower than Algan's visible width. Pass

--- a/algan/mobs/manim_compat.py
+++ b/algan/mobs/manim_compat.py
@@ -674,6 +674,167 @@ class ManimCompatMob(ManimMob):
         return sorted(set(super().__dir__()) | set(dir(self.manim_mobject)))
 
 
+# Generated wrappers inherit their backing class's docstring, which is the right
+# default: Manim's prose describes arguments that really do work here. It is the
+# wrong answer for the LaTeX-bearing classes, whose Manim docstrings carry
+# ``.. manim::`` examples -- Manim scene code, executed and rendered into Algan's
+# own reference pages, teaching a script that will not run. Those get an
+# Algan-authored docstring instead. See DOCSTRINGS.md.
+_MATHTEX_DOC = """A LaTeX string typeset in math mode, wrapping Manim's ``MathTex``.
+
+Manim compiles the formula and builds its glyph outlines; Algan converts those
+to cubic bezier circuits and animates them on its own timeline. Manim's own
+arguments work as written -- ``tex_to_color_map`` and ``substrings_to_isolate``
+included -- and Manim methods Algan does not implement are delegated to the
+backing object.
+
+Reach for Algan's :class:`~algan.mobs.text.Tex` when you are not porting a
+script. The two produce the same outlines (``MathTex("x^2")`` matches
+``Tex("x^2", font_size=48)``, because Algan's ``Tex`` also builds at Manim's 48
+and then scales), but this one is a single Mob with no per-glyph views:
+``formula[0]`` raises :class:`TypeError`, and character indexing,
+:meth:`~algan.mobs.text.Tex.get_segment` and :meth:`~algan.mobs.text.Tex.write`
+all live on ``Tex`` instead.
+
+Animation
+---------
+Constructing one records nothing: LaTeX runs immediately and the Mob joins the
+active Scene unspawned. Call
+:meth:`~algan.animatable_base.animatable.Animatable.spawn` to make it appear.
+Everything after that -- ``formula.color = BLUE``, a move, a delegated Manim
+edit -- is recorded on the timeline like any other Mob's, over the current
+context's duration.
+
+Parameters
+----------
+*tex_strings
+    One or more LaTeX sources, joined by ``arg_separator`` and compiled as a
+    single document.
+arg_separator
+    Inserted between consecutive ``tex_strings`` in the compiled source.
+    Defaults to ``" "``, one space.
+substrings_to_isolate
+    Substrings to split the source on before compiling, so each ends up as its
+    own piece of the result. Defaults to ``None``, meaning no extra splitting
+    beyond what the separate ``tex_strings`` already give.
+tex_to_color_map
+    Maps a substring of the source to the colour its glyphs take; the substring
+    is isolated for you. Accepts Manim colours, hex strings, or Algan
+    :class:`~algan.constants.color.Color` values -- an Algan colour is converted
+    to hex on the way through Manim, so its glow and opacity are dropped and
+    have to be set on the Mob afterwards. Defaults to ``None``, one colour
+    throughout.
+tex_environment
+    Name of the LaTeX environment to typeset in, such as ``"gather*"``.
+    Defaults to ``"align*"``.
+**kwargs
+    Manim's remaining ``MathTex`` arguments -- notably ``font_size`` (defaults
+    to ``48``), ``color``, ``tex_template``, ``stroke_width`` and
+    ``should_center`` -- plus the Algan-only ``scene``, ``add_to_scene``,
+    ``glow`` and ``glow_radius``.
+
+Raises
+------
+:class:`ValueError`
+    If LaTeX fails to compile the source. The most common cause is
+    ``tex_to_color_map`` or ``substrings_to_isolate``: they split the source on
+    the literal substring, so a key that also occurs inside a control sequence
+    or a brace group cuts it in half. Colouring ``"n"`` in a formula containing
+    ``\\infty`` is enough to do it. Pick a key that stands alone, or pass the
+    pieces as separate ``tex_strings``.
+
+See Also
+--------
+:class:`~algan.mobs.text.Tex` : Algan's own LaTeX Mob, with per-glyph views,
+    segments and the hand-writing animation.
+
+Examples
+--------
+A formula, and one with two symbols picked out by ``tex_to_color_map``:
+
+.. algan:: Example1MathTex
+    :save_last_frame:
+
+    from algan import *
+
+    MathTex(r"\\sum_{n=1}^{\\infty} \\frac{1}{n^2} = \\frac{\\pi^2}{6}",
+            font_size=36).move(UP * 0.5).spawn()
+    MathTex(r"a^2 + b^2 = c^2", font_size=36,
+            tex_to_color_map={"a": BLUE, "b": YELLOW}).move(DOWN * 0.5).spawn()
+
+    Scene.save_video()
+"""
+
+_TITLE_DOC = """An underlined heading, wrapping Manim's ``Title``.
+
+The text is typeset by LaTeX in text mode (so ``Title("Chapter 1")`` reads as
+written, no maths escaping needed) with a horizontal rule beneath it, and the
+whole thing is moved to the top of the frame.
+
+**The frame it moves to the top of is Manim's, not Algan's.** Manim's is 8 world
+units tall; Algan's default camera shows about 7, so a ``Title`` left where it
+puts itself is clipped along its top edge. Move it down about a unit, or scale
+it first. :meth:`~algan.animatable_base.mob_movement.MobMovementMixin.move_to_edge`
+is the obvious fix and is the wrong one -- a compatibility Mob's ``location`` is
+the centre of the backing Mobject's own points rather than of the composite, so
+on a ``Title`` (whose rule is a submobject) the edge is measured from the wrong
+place and the text ends up further off-screen, not closer.
+
+The default rule is sized from Manim's frame too, at ``frame_width - 2``, which
+comes out just narrower than Algan's visible width. Pass
+``match_underline_width_to_text=True`` for a rule the width of the words.
+
+Animation
+---------
+Constructing one records nothing: LaTeX runs immediately and the Mob joins the
+active Scene unspawned. Call
+:meth:`~algan.animatable_base.animatable.Animatable.spawn` to make it appear;
+later changes are recorded on the timeline like any other Mob's.
+
+Parameters
+----------
+*text_parts
+    One or more strings, joined and typeset as a single line of text.
+include_underline
+    Whether to draw the rule beneath the text. Defaults to ``True``.
+match_underline_width_to_text
+    Whether the rule spans only the width of the text. Defaults to ``False``,
+    which spans Manim's frame width less 2 world units instead.
+underline_buff
+    Gap between the text and the rule, in world units. Defaults to ``0.25``
+    (Manim's ``MED_SMALL_BUFF``).
+**kwargs
+    Manim's remaining ``Tex`` arguments -- notably ``font_size`` (defaults to
+    ``48``), ``color`` and ``tex_template`` -- plus the Algan-only ``scene``,
+    ``add_to_scene``, ``glow`` and ``glow_radius``.
+
+Attributes
+----------
+underline
+    The rule Mob, present only when ``include_underline`` is true. Animate it
+    like any other Mob.
+
+Examples
+--------
+A title placed where Algan's camera can see all of it, over a shape:
+
+.. algan:: Example1Title
+    :save_last_frame:
+
+    from algan import *
+
+    Title("A Title", match_underline_width_to_text=True).move(DOWN * 1).spawn()
+    Circle(radius=0.8, color=BLUE).spawn()
+
+    Scene.save_video()
+"""
+
+_WRAPPER_DOCSTRINGS: dict[str, str] = {
+    "MathTex": _MATHTEX_DOC,
+    "Title": _TITLE_DOC,
+}
+
+
 def _make_manim_wrapper(name: str):
     manim_class = getattr(_manim, name)
     wrapper = type(
@@ -682,7 +843,7 @@ def _make_manim_wrapper(name: str):
         {
             "_manim_class": manim_class,
             "__module__": __name__,
-            "__doc__": manim_class.__doc__,
+            "__doc__": _WRAPPER_DOCSTRINGS.get(name, manim_class.__doc__),
         },
     )
     with contextlib.suppress(TypeError, ValueError):

--- a/algan/mobs/manim_compat.py
+++ b/algan/mobs/manim_compat.py
@@ -775,16 +775,9 @@ whole thing is moved to the top of the frame.
 against the edge.** Manim's frame is 8 world units tall and its ``to_edge``
 leaves a 0.5 gap, so the title's top comes to rest at ``y = 3.5`` -- which is
 exactly where Algan's default camera puts its top border. Nothing is cut off,
-but the text touches the frame edge with no margin at all. ``.move(DOWN * 1)``
-insets it.
-
-:meth:`~algan.animatable_base.mob_movement.MobMovementMixin.move_to_edge` is the
-obvious way to inset it and does the opposite -- it pushes the title ``buffer``
-further out. That is not a ``Title`` quirk: the method takes its inset direction
-from ``normalize(boundary - border)``, and for a Mob whose boundary already lies
-*on* the border that difference is zero, so float rounding decides the sign.
-Here it resolves outward. A Mob that starts clearly outside the frame is pulled
-back in correctly; it is landing exactly on the border that is degenerate.
+but the text touches the frame edge with no margin at all. Call
+:meth:`~algan.animatable_base.mob_movement.MobMovementMixin.move_to_edge` to
+inset it by the usual buffer, or ``.move(DOWN * 1)`` to place it by hand.
 
 The default rule is sized from Manim's frame too, at ``frame_width - 2``, which
 comes out just narrower than Algan's visible width. Pass

--- a/algan/mobs/shapes_3d.py
+++ b/algan/mobs/shapes_3d.py
@@ -203,20 +203,30 @@ class Sphere(Surface):
         both. Manim counts patches and Algan counts sampled vertices, so each value
         is used as ``grid_width``/``grid_height`` plus one. Defaults to ``None``,
         meaning Algan sizes the grid itself from ``geometry_tolerance``.
-    u_range, v_range
-        Parametric domain, in radians, accepted for Manim compatibility.
-
-        .. note::
-
-            These are stored but do **not** currently change the sphere's geometry:
-            :meth:`coord_function` always sweeps a full longitude/latitude grid, so
-            a partial range still builds a whole sphere. Build a partial sphere with
-            :class:`~algan.mobs.surfaces.surface.Surface` and your own coordinate
-            function instead. Defaults to ``(0, 2 * pi)`` and ``(0, pi)``.
+    u_range
+        Azimuthal sweep around the sphere's own up axis, **in radians** -- a
+        Manim-parity domain, which is why it contradicts Algan's usual degrees.
+        The sweep starts at the sphere's ``LEFT`` and turns through ``OUT``,
+        ``RIGHT`` and ``IN``, so ``(0, PI)`` builds the ``OUT`` half -- the one
+        facing the camera. Defaults to ``(0, 2 * PI)``, all the way round.
+    v_range
+        Pole-to-pole sweep, **in radians** and Manim-parity for the same reason:
+        ``0`` is the ``DOWN`` pole and ``PI`` the ``UP`` one. ``(0, PI / 2)``
+        builds the bottom hemisphere, ``(PI / 4, 3 * PI / 4)`` a band around the
+        equator. Defaults to ``(0, PI)``, pole to pole.
     *args, **kwargs
         Passed to :class:`~algan.mobs.surfaces.surface.Surface` -- notably
         ``color``, ``checkered_color``, ``grid_width``/``grid_height`` and the
         texture maps.
+
+    Notes
+    -----
+    A partial ``u_range`` or ``v_range`` builds an open shell. The cut edges are
+    not capped, so the inside of the surface shows through them, and the shape
+    is re-tessellated from scratch rather than carved out of the whole sphere's
+    grid. The tessellation search only promises ``geometry_tolerance``, and a
+    sweep that still reaches a pole needs a finer grid there than a closed
+    sphere does -- so a partial sphere is not automatically the cheaper one.
 
     Examples
     --------
@@ -228,6 +238,19 @@ class Sphere(Surface):
         from algan import *
 
         Sphere(radius=0.8, color=BLUE).spawn()
+
+        Scene.save_video()
+
+    A hemisphere, and a band around the equator:
+
+    .. algan:: Example2Sphere
+        :save_last_frame:
+
+        from algan import *
+
+        Sphere(radius=0.7, v_range=(0, PI / 2), color=BLUE).move(LEFT * 0.9).spawn()
+        Sphere(radius=0.7, v_range=(PI / 3, 2 * PI / 3),
+               color=YELLOW).move(RIGHT * 0.9).spawn()
 
         Scene.save_video()
     """
@@ -252,11 +275,20 @@ class Sphere(Surface):
     def coord_function(self, coords_2d):
         # Keep the original Algan sampling orientation.  Although a sphere is
         # rotationally symmetric, rotating its latitude/longitude grid changes
-        # triangle placement, normals, and therefore pixel output.
+        # triangle placement, normals, and therefore pixel output.  That is why
+        # the parametric ranges are folded into the endpoints of the existing
+        # interpolation rather than applied on top of it: at the default domain
+        # the two endpoints come out as -pi/+pi and -pi/2/+pi/2 exactly, so the
+        # arithmetic below is bit-for-bit what it was before the ranges were
+        # honoured, and only a non-default range moves a vertex.
         x = coords_2d[..., 0]
         y = coords_2d[..., 1]
-        longitude = -torch.pi * (1 - x) + x * torch.pi
-        latitude = -torch.pi * 0.5 * (1 - y) + y * torch.pi * 0.5
+        longitude_start = -torch.pi + self.u_range[0]
+        longitude_end = -torch.pi + self.u_range[1]
+        latitude_start = -torch.pi * 0.5 + self.v_range[0]
+        latitude_end = -torch.pi * 0.5 + self.v_range[1]
+        longitude = longitude_start * (1 - x) + x * longitude_end
+        latitude = latitude_start * (1 - y) + y * latitude_end
         coords_3d = torch.stack(
             (
                 torch.cos(latitude) * torch.cos(longitude),
@@ -463,16 +495,17 @@ class Cylinder(Surface):
         Axis the cylinder runs along, shape ``(*, 3)``; it need not be normalized.
         Defaults to ``UP`` (the +y axis).
     v_range
-        Parametric domain, in radians, accepted for Manim compatibility.
-
-        .. note::
-
-            Stored but not currently used by :meth:`coord_function`, which always
-            sweeps the full circle, so a partial range still builds a whole
-            cylinder. Defaults to ``(0, 2 * pi)``.
+        Azimuthal sweep around the cylinder's axis, **in radians** -- a
+        Manim-parity domain, which is why it contradicts Algan's usual degrees.
+        The sweep starts on the side the cylinder's forward direction points at
+        (``IN``, for the default ``direction=UP``) and turns toward its left, so
+        ``(0, PI)`` builds the ``LEFT`` half of the tube. Defaults to
+        ``(0, 2 * PI)``, the closed tube. The extent *along* the axis comes from
+        ``height``, which is where Manim also gets its ``u_range`` from.
     show_ends
         Whether to cap both ends with filled circles. Defaults to ``False``: the
-        tube is open at both ends.
+        tube is open at both ends. The caps are whole circles even when
+        ``v_range`` is partial, matching Manim.
     resolution
         Manim-style grid resolution as ``(u_patches, v_patches)``, or one int for
         both; each value becomes ``grid_width``/``grid_height`` plus one, since
@@ -484,6 +517,14 @@ class Cylinder(Surface):
     *args, **kwargs
         Passed to :class:`~algan.mobs.surfaces.surface.Surface`.
 
+    Notes
+    -----
+    A partial ``v_range`` builds an open half-pipe, not a solid: the cut runs
+    the length of the tube and the inside of the surface shows through it. The
+    shape is re-tessellated from scratch, and since the tessellation search only
+    promises ``geometry_tolerance``, a partial sweep can end up with a denser
+    grid than the closed tube.
+
     Examples
     --------
     A capped cylinder lying along the screen's x axis:
@@ -494,6 +535,20 @@ class Cylinder(Surface):
         from algan import *
 
         Cylinder(radius=0.4, height=1.6, direction=RIGHT, show_ends=True).spawn()
+
+        Scene.save_video()
+
+    Half a tube, cut along its length and turned so the shell faces the camera
+    (unrotated, the cut runs straight through the line of sight and the half
+    reads as a flat panel):
+
+    .. algan:: Example2Cylinder
+        :save_last_frame:
+
+        from algan import *
+
+        Cylinder(radius=0.7, height=1.4, v_range=(0, PI),
+                 color=BLUE).rotate(-90, UP).spawn()
 
         Scene.save_video()
     """
@@ -547,12 +602,17 @@ class Cylinder(Surface):
 
     def coord_function(self, uv):
         uv[..., 1:] /= uv[..., 1:].amax()
-        u = -uv[..., :1]
+        # ``v_range`` is Manim's azimuthal domain, but Algan's grid carries the
+        # azimuth on the *first* uv component and the axial parameter on the
+        # second, so the sweep is applied to ``uv[..., :1]``.  Written as one
+        # negated product so that the default (0, 2*pi) reduces to the previous
+        # ``-uv * pi * 2`` bit for bit: only a partial sweep moves a vertex.
+        u = -(self.v_range[0] + uv[..., :1] * (self.v_range[1] - self.v_range[0]))
         v = uv[..., 1:]
         return (
-            (u * torch.pi * 2).sin() * self.radius * self.get_right_basis()
+            u.sin() * self.radius * self.get_right_basis()
             + (v - 0.5) * self.height * self.get_upwards_basis()
-            + (u * torch.pi * 2).cos() * self.radius * self.get_forward_basis()
+            + u.cos() * self.radius * self.get_forward_basis()
         )
 
     def normal_function(self, uv):

--- a/algan/mobs/text.py
+++ b/algan/mobs/text.py
@@ -76,9 +76,134 @@ def make_manim_dir():
 
 
 class Tex(Mob):
-    """LaTeX text rendered as one packed batch of cubic bezier glyphs.
+    r"""LaTeX compiled to one packed batch of cubic bezier glyphs.
 
-    ``character_mobs`` provides lazy indexed views into the batch.
+    The string is typeset in LaTeX's **math mode**, so ``Tex("x^2")`` is a
+    squared x rather than the three literal characters. Pass ``latex=False`` for
+    prose, or use :class:`~algan.mobs.text.Text`, which is this class wired to a
+    Pango font renderer instead.
+
+    The glyphs are outlines, not bitmaps: the text stays sharp at any scale and
+    morphs into other 2-D shapes like any other bezier Mob. They arrive as a
+    single packed Mob rather than one Mob per character, which is what makes a
+    long string cheap. Index it to animate one glyph -- ``equation[3]`` is a
+    view sharing the batch's rows, so moving it moves that glyph of the
+    original, and it needs no spawning of its own. Several source strings become
+    several *segments*, addressable with :meth:`get_segment`, which is the usual
+    way to highlight one term of an equation.
+
+    :class:`~algan.mobs.manim_compat.MathTex` renders LaTeX too and is a
+    different object: it is the Manim-compatibility wrapper, for when a ported
+    script needs ``tex_to_color_map`` or Manim method delegation. This class is
+    the native one, and the only one with per-glyph indexing,
+    :meth:`get_segment` and :meth:`write`.
+
+    Animation
+    ---------
+    Constructing a ``Tex`` records nothing: LaTeX runs immediately and the Mob
+    joins the active Scene unspawned. :meth:`~algan.animatable_base.animatable.Animatable.spawn`
+    is what plays its entrance -- :meth:`on_create`, a diagonal fade running down
+    and to the right so the words arrive in reading order, lasting 1 second
+    regardless of the enclosing context. ``Tex(...).spawn(False)`` skips it, which
+    is what :meth:`write` wants.
+
+    Parameters
+    ----------
+    *tex_strings
+        One or more LaTeX sources. Each becomes a segment retrievable with
+        :meth:`get_segment`, and they are compiled as one document so a
+        ``\left`` in one string can close in the next. A single list or tuple is
+        unpacked, and no strings at all gives an empty ``Tex``.
+    arg_separator
+        Inserted between consecutive ``tex_strings`` in the compiled source (and
+        used to join them when ``latex=False``). Defaults to ``" "``, one space.
+    tex_environment
+        Name of the LaTeX environment to typeset in, such as ``"align*"`` or
+        ``"gather*"``. Defaults to ``None``, meaning Manim's own default of
+        ``align*``.
+    font_size
+        Glyph size in Manim's font-size units. The batch is always built at 48
+        and then scaled by ``font_size / 48``, so this is a scale factor in
+        disguise: ``48`` matches Manim's default text size and ``24`` is half of
+        it. Defaults to ``24``.
+    latex
+        Whether to typeset through LaTeX. ``False`` treats the strings as plain
+        text and routes them to Manim's Pango renderer instead -- an Algan
+        extension, and how :class:`~algan.mobs.text.Text` is built. Defaults to
+        ``True``.
+    pango_kwargs
+        Styling forwarded to the Pango renderer when ``latex=False``: ``font``,
+        ``weight``, ``slant``, ``line_spacing``, ``t2c``, ``gradient`` and the
+        rest of Manim's ``Text`` arguments. Ignored under LaTeX. Defaults to
+        ``None`` (no styling). Prefer :class:`~algan.mobs.text.Text`, which
+        exposes these as ordinary named arguments.
+    pango_color_map
+        Maps the hex strings in ``pango_kwargs`` back to the Algan
+        :class:`~algan.constants.color.Color` objects they came from, so glow
+        and opacity survive the round trip through Pango's SVG output (a hex
+        string cannot carry either). Defaults to ``None``. Set for you by
+        :class:`~algan.mobs.text.Text`.
+    sync_border_color
+        Whether a glyph coloured by Pango styling also gets that colour on its
+        border. Only has an effect when a border is actually drawn
+        (``border_width`` above 0). Defaults to ``True``; pass an explicit
+        ``border_color`` to keep one outline colour across styled glyphs.
+    **kwargs
+        Passed to :class:`~algan.animatable_base.mob.Mob` and to the packed
+        :class:`~algan.mobs.bezier_circuit.BezierCircuitCubic` -- notably
+        ``color`` (defaults to ``WHITE``), ``border_color``, ``border_width``
+        (defaults to ``0``, no outline), ``location`` and ``scene``. One extra
+        keyword is consumed here: ``preamble``, a string of LaTeX appended to
+        Manim's default preamble, for ``\usepackage`` lines a formula needs.
+
+    Attributes
+    ----------
+    character_mobs
+        Lazy per-glyph views into the packed batch, in typeset order. This is
+        what ``tex[i]`` and :meth:`write` animate.
+    tex_strings
+        The source strings as given, after list/tuple unpacking, as a tuple.
+    latex
+        Whether this text was typeset by LaTeX rather than by Pango.
+
+    Examples
+    --------
+    A formula, one segment per term, with the middle term picked out:
+
+    .. algan:: Example1Tex
+        :save_last_frame:
+
+        from algan import *
+
+        equation = Tex(r"e^{i\pi}", "+", "1", "=", "0", font_size=48).spawn()
+        equation.get_segment(2).color = YELLOW
+
+        Scene.save_video()
+
+    ``latex=False`` for prose, and a larger ``font_size``:
+
+    .. algan:: Example2Tex
+        :save_last_frame:
+
+        from algan import *
+
+        Tex("Not a formula", latex=False, font_size=48, color=BLUE).spawn()
+
+        Scene.save_video()
+
+    Individual glyphs are views, so animating one animates the original:
+
+    .. algan:: Example3Tex
+        :save_last_frame:
+
+        from algan import *
+
+        word = Tex("ALGAN", font_size=48).spawn()
+        with Sync():
+            word[0].move(UP * 0.3)
+            word[4].move(DOWN * 0.3)
+
+        Scene.save_video()
     """
 
     triangulated = False
@@ -95,22 +220,6 @@ class Tex(Mob):
         sync_border_color=True,
         **kwargs,
     ):
-        """Build TeX from one or more strings using Manim's public API.
-
-        ``latex`` is retained as an Algan extension: when false, the strings are
-        treated as plain text.  Manim's ``arg_separator`` and
-        ``tex_environment`` keyword arguments are accepted directly.
-
-        ``pango_kwargs`` (non-latex only) is forwarded to ``manim.Text`` so
-        Pango styling (font, weight, slant, t2c, gradient, ...) reaches the
-        glyph renderer.  Per-glyph fill colors produced by that styling are
-        read back off the manim submobjects and applied to the packed glyph
-        batch; ``pango_color_map`` maps hex strings back to the original algan
-        colors so glow/opacity survive the SVG round trip.  Glyphs left at
-        manim's default WHITE keep the algan base color.  ``sync_border_color``
-        copies each styled glyph's fill color to its border when a border is
-        drawn (disabled when the caller supplied an explicit border color).
-        """
         if kwargs.get("scene") is None:
             kwargs["scene"] = active_scene_for_new_mob()
         make_manim_dir()
@@ -536,11 +645,94 @@ class Text(Tex):
     Parameters
     ----------
     text
-        The text to display.
+        The text to display. Cast to ``str``, and tabs are expanded to
+        ``tab_width`` spaces.
+    fill_opacity
+        Opacity of the glyph interiors, 0 for invisible and 1 for solid. Manim's
+        spelling of Algan's ``opacity``. Defaults to ``1.0``.
+    stroke_width
+        Width of the outline drawn around each glyph, in Manim's stroke units --
+        halved on the way in, because Algan's ``border_width`` is half of
+        Manim's for the same visual weight. Defaults to ``0``, no outline.
+    color
+        Colour of the glyphs, and of their outline if one is drawn. Accepts an
+        Algan :class:`~algan.constants.color.Color`, a named constant such as
+        ``BLUE``, or anything ``Color()`` accepts. Defaults to ``None``, meaning
+        Algan's default text colour (``WHITE``).
+    font_size
+        Glyph size in Manim's font-size units; the glyphs are built at 48 and
+        scaled by ``font_size / 48``. Defaults to ``48``, so plain ``Text`` comes
+        out twice the size of plain :class:`~algan.mobs.text.Tex`.
+    line_spacing
+        Distance between baselines of a multi-line string, in Pango's units.
+        Defaults to ``-1``, meaning Pango's own spacing for the font.
+    font
+        Font family name, as installed on the system. Defaults to ``""``,
+        meaning Pango's default family.
+    slant
+        ``"NORMAL"``, ``"ITALIC"`` or ``"OBLIQUE"``. Defaults to ``"NORMAL"``.
+    weight
+        A Pango weight name -- ``"THIN"``, ``"LIGHT"``, ``"NORMAL"``,
+        ``"MEDIUM"``, ``"SEMIBOLD"``, ``"BOLD"``, ``"HEAVY"``, and the rest.
+        Defaults to ``"NORMAL"``.
+    t2c
+        Text-to-colour: maps a substring to the colour its glyphs take. Colour
+        values may be Algan colours (glow and opacity survive), hex strings, or
+        named Manim colours. A value of pure white is indistinguishable from
+        unstyled text and falls back to the base colour. Defaults to ``None``.
+    t2f
+        Text-to-font: maps a substring to a font family. Defaults to ``None``.
+    t2g
+        Text-to-gradient: maps a substring to a tuple of colours to fade
+        between across it. Defaults to ``None``.
+    t2s
+        Text-to-slant: maps a substring to a slant name. Defaults to ``None``.
+    t2w
+        Text-to-weight: maps a substring to a weight name. Defaults to ``None``.
+    gradient
+        A tuple of colours faded across the whole string. Defaults to ``None``,
+        one flat colour.
+    tab_width
+        How many spaces a tab in ``text`` expands to. Defaults to ``4``.
+    warn_missing_font
+        Whether to log a warning when ``font`` is not installed. Defaults to
+        ``True``.
+    height
+        Scale the finished text uniformly so it is this tall, in world units.
+        Defaults to ``None``, its natural size for ``font_size``.
+    width
+        Scale the finished text uniformly so it is this wide, in world units.
+        Applied after ``height``, so passing both leaves the width matched and
+        the height wherever the aspect ratio puts it. Defaults to ``None``.
+    should_center
+        Whether to move the finished text to the world origin. Defaults to
+        ``True``; pass ``False`` to keep the position ``location`` gave it.
+    disable_ligatures
+        Whether to render each character separately rather than letting the font
+        combine pairs such as "fi". Slower, but it makes ``text[i]`` line up
+        with the i-th character. Defaults to ``False``.
+    use_svg_cache
+        Accepted for Manim parity and has no effect: Algan caches the glyph
+        geometry itself, keyed on the source, whatever this is set to. Defaults
+        to ``False``.
     **kwargs
-        Passed to :class:`~algan.mobs.text.Tex` -- notably ``font_size``, ``color``,
-        ``location``, and
-        the Pango styling arguments described above.
+        Passed to :class:`~algan.mobs.text.Tex` -- notably ``location``,
+        ``border_color``, ``scene`` and ``add_to_scene``.
+
+    Examples
+    --------
+    Plain prose, and the same words with one span coloured:
+
+    .. algan:: Example1Text
+        :save_last_frame:
+
+        from algan import *
+
+        Text("Hello, world", font_size=36).move(UP * 0.5).spawn()
+        Text("Hello, world", font_size=36,
+             t2c={"world": BLUE}).move(DOWN * 0.5).spawn()
+
+        Scene.save_video()
     """
 
     def __init__(
@@ -693,10 +885,58 @@ class TextTriangulated(TexTriangulated):
 
 
 class MarkupText(Text):
-    """Text accepting Manim/Pango markup syntax.
+    """Plain text from a Pango-markup source, with the markup stripped out.
 
-    Markup is stripped when the optional Pango renderer is unavailable; the
-    resulting textual content, entities, and line breaks are preserved.
+    Manim's markup syntax is accepted so a ported script keeps running, but the
+    tags never reach the glyph renderer: ``<br/>`` becomes a line break, HTML
+    entities are unescaped, and every other tag is deleted before the text is
+    typeset. This happens whether or not the optional Pango renderer is
+    available, so a ``<span foreground='red'>`` span comes out in the Mob's own
+    colour, not red. The source you passed is kept on ``original_text``.
+
+    To colour or restyle part of a string, use :class:`~algan.mobs.text.Text`'s
+    ``t2c`` / ``t2f`` / ``t2s`` / ``t2w`` / ``t2g`` arguments instead -- those do
+    reach the renderer.
+
+    Parameters
+    ----------
+    text
+        The marked-up source. Tags are stripped, ``<br/>`` becomes a newline and
+        entities such as ``&amp;`` are unescaped; what remains is typeset.
+    justify
+        Accepted for Manim parity and has no effect on the rendered text; it is
+        stored on the Mob as ``justify``. Defaults to ``False``.
+    fill_opacity, stroke_width, color, font_size, line_spacing
+        As :class:`~algan.mobs.text.Text`, with the same defaults.
+    font, slant, weight, gradient, disable_ligatures, warn_missing_font
+        As :class:`~algan.mobs.text.Text`, with the same defaults.
+    tab_width, height, width, should_center
+        As :class:`~algan.mobs.text.Text`, with the same defaults. All of these
+        are redeclared here only so this constructor's signature matches
+        Manim's.
+    **kwargs
+        Passed to :class:`~algan.mobs.text.Text`.
+
+    Attributes
+    ----------
+    original_text
+        The markup source exactly as given, before stripping.
+
+    Examples
+    --------
+    A markup string, and the ``Text`` spelling that actually colours the span:
+
+    .. algan:: Example1MarkupText
+        :save_last_frame:
+
+        from algan import *
+
+        MarkupText("<b>bold</b> markup is stripped",
+                   font_size=32).move(UP * 0.5).spawn()
+        Text("t2c is not", font_size=32,
+             t2c={"not": BLUE}).move(DOWN * 0.5).spawn()
+
+        Scene.save_video()
     """
 
     def __init__(

--- a/docs/source/manim_user_quickstart/migrating_from_manim.rst
+++ b/docs/source/manim_user_quickstart/migrating_from_manim.rst
@@ -200,14 +200,10 @@ outlines: ``MathTex("x^2")`` matches ``Tex("x^2", font_size=48)``.
     lands somewhere Algan did not choose. ``Title`` is the one most people meet:
     Manim's ``to_edge(UP)`` leaves a 0.5 gap below its own frame top, putting the
     title's top at ``y = 3.5`` -- exactly Algan's top border. Nothing is cut off,
-    but it sits flush against the frame edge with no margin. ``.move(DOWN * 1)``
-    insets it.
-
-    Reach for that rather than
-    :meth:`~algan.animatable_base.mob_movement.MobMovementMixin.move_to_edge`,
-    which moves a Mob already touching the border *further* out: it takes its
-    inset direction from ``normalize(boundary - border)``, which is degenerate
-    when the boundary lies on the border, so float rounding picks the sign.
+    but it sits flush against the frame edge with no margin. Call
+    :meth:`~algan.animatable_base.mob_movement.MobMovementMixin.move_to_edge` to
+    inset it by Algan's usual buffer, or place it by hand with
+    ``.move(DOWN * 1)``.
 
 For a compatible Manim vector mobject, wrap it in
 :class:`~algan.mobs.manim_mob.ManimMob`:

--- a/docs/source/manim_user_quickstart/migrating_from_manim.rst
+++ b/docs/source/manim_user_quickstart/migrating_from_manim.rst
@@ -195,14 +195,19 @@ outlines: ``MathTex("x^2")`` matches ``Tex("x^2", font_size=48)``.
 
 .. note::
 
-    Manim's frame is 14.22 by 8 world units; Algan's default camera shows about
-    12.4 by 7. Anything that positions itself against Manim's frame therefore
-    lands outside Algan's view. ``Title`` is the one most people meet: it calls
-    Manim's ``to_edge(UP)`` and so renders clipped along the top. Move it down
-    about a unit, or scale it first, rather than reaching for
-    :meth:`~algan.animatable_base.mob_movement.MobMovementMixin.move_to_edge` --
-    on a compatibility Mob with submobjects that measures the edge from the
-    backing object's own centre and pushes the Mob further off-screen.
+    Manim's frame is 14.22 by 8 world units; Algan's default camera shows
+    12.44 by 7. Anything that positions itself against Manim's frame therefore
+    lands somewhere Algan did not choose. ``Title`` is the one most people meet:
+    Manim's ``to_edge(UP)`` leaves a 0.5 gap below its own frame top, putting the
+    title's top at ``y = 3.5`` -- exactly Algan's top border. Nothing is cut off,
+    but it sits flush against the frame edge with no margin. ``.move(DOWN * 1)``
+    insets it.
+
+    Reach for that rather than
+    :meth:`~algan.animatable_base.mob_movement.MobMovementMixin.move_to_edge`,
+    which moves a Mob already touching the border *further* out: it takes its
+    inset direction from ``normalize(boundary - border)``, which is degenerate
+    when the boundary lies on the border, so float rounding picks the sign.
 
 For a compatible Manim vector mobject, wrap it in
 :class:`~algan.mobs.manim_mob.ManimMob`:

--- a/docs/source/manim_user_quickstart/migrating_from_manim.rst
+++ b/docs/source/manim_user_quickstart/migrating_from_manim.rst
@@ -149,9 +149,15 @@ A few Manim-parity surfaces keep Manim's radians on purpose. These take
 * ``Wiggle(rotation_angle=...)``.
 * The ``u_range`` / ``v_range`` parametric domains of :class:`~algan.mobs.shapes_3d.Sphere`,
   ``Cone``, ``Cylinder`` and ``Torus`` -- these are parameter intervals rather
-  than rotations. Note that only ``Cone``'s ``v_range`` and ``Torus``'s two
-  ranges actually restrict the geometry; ``Sphere`` and ``Cylinder`` accept
-  theirs for compatibility but always build the whole shape.
+  than rotations. All of them restrict the geometry, so a partial range builds a
+  partial shape: an open shell with uncapped cut edges, re-tessellated from
+  scratch rather than carved out of the whole shape's grid. Which parameter is
+  which follows Manim: ``Sphere``'s ``u_range`` is the azimuth and its
+  ``v_range`` runs pole to pole, while ``Cylinder``'s and ``Cone``'s ``v_range``
+  is the azimuth about the axis (the extent along the axis comes from
+  ``height``, as it does in Manim). The zero of each sweep is Algan's own seam
+  rather than Manim's, so a half shape comes out rotated relative to Manim's --
+  the docstrings say where each one starts.
 
 Every one of those is a *constructor argument* handed straight to Manim. No
 Algan **method** is among them, so there is no Mob anywhere whose ``rotate``
@@ -179,8 +185,27 @@ Text, TeX, and imported Manim mobjects
 ======================================
 
 Algan provides native :class:`~algan.mobs.text.Text` and
-:class:`~algan.mobs.text.Tex` mobs. For a compatible Manim vector mobject, wrap
-it in :class:`~algan.mobs.manim_mob.ManimMob`:
+:class:`~algan.mobs.text.Tex` mobs. ``MathTex`` and ``Title`` are *not* native:
+they are compatibility wrappers around Manim's classes, so they take Manim's
+arguments (``tex_to_color_map``, ``include_underline``) but are single Mobs with
+no per-glyph views -- ``formula[0]`` raises, and ``write()`` and ``get_segment()``
+live on :class:`~algan.mobs.text.Tex`. Where a script does not need Manim's own
+arguments, ``Tex`` is the better landing place, and it produces the same
+outlines: ``MathTex("x^2")`` matches ``Tex("x^2", font_size=48)``.
+
+.. note::
+
+    Manim's frame is 14.22 by 8 world units; Algan's default camera shows about
+    12.4 by 7. Anything that positions itself against Manim's frame therefore
+    lands outside Algan's view. ``Title`` is the one most people meet: it calls
+    Manim's ``to_edge(UP)`` and so renders clipped along the top. Move it down
+    about a unit, or scale it first, rather than reaching for
+    :meth:`~algan.animatable_base.mob_movement.MobMovementMixin.move_to_edge` --
+    on a compatibility Mob with submobjects that measures the edge from the
+    backing object's own centre and pushes the Mob further off-screen.
+
+For a compatible Manim vector mobject, wrap it in
+:class:`~algan.mobs.manim_mob.ManimMob`:
 
 .. algan-doc-check: skip -- needs diagram.svg, which does not ship with the docs
 

--- a/tests/unit_tests/test_move_to_edge_inset.py
+++ b/tests/unit_tests/test_move_to_edge_inset.py
@@ -1,0 +1,124 @@
+"""``move_to_edge`` insets the boundary *inside* the border, from anywhere.
+
+The sign is the whole point of this file. ``move_to_edge`` used to take its
+inset direction from ``normalize(boundary - border)`` -- read off where the Mob
+happens to be rather than off the edge that was asked for. The border is cast
+from the boundary along the edge, so that difference is antiparallel to the edge
+only while the Mob is inside the frame. Two cases fall out of it:
+
+* a Mob already past the edge came to rest ``buffer`` *outside* the border,
+  still off-screen, rather than being brought in;
+* a boundary resting exactly *on* the border made the difference zero, and
+  ``F.normalize`` amplified float32 noise into a whole unit vector, so rounding
+  picked the direction. A Manim-compatibility ``Title`` lands exactly there,
+  because Manim's ``to_edge`` insets by 0.5 from a frame 8 units tall and
+  Algan's top border is at 3.5.
+
+Neither was caught, because the existing coverage in
+``test_manim_compat_movement.py`` measures the gap with ``.norm()``. An
+unsigned gap cannot tell 0.6 inside from 0.6 outside. Everything here is signed.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from algan import DOWN, LEFT, RIGHT, SETTINGS, UP, SceneManager, Square
+
+EDGES = {"up": UP, "down": DOWN, "left": LEFT, "right": RIGHT}
+
+
+@pytest.fixture(autouse=True)
+def reset_scene():
+    SceneManager.reset()
+    yield
+    SceneManager.reset()
+
+
+def _buffer() -> float:
+    return float(SETTINGS.style.buffer)
+
+
+def _signed_inset(mob, edge) -> float:
+    """How far inside the border the Mob's boundary sits, along ``edge``.
+
+    Positive is inside the frame, negative is past the border. The border is
+    cast from the boundary along ``edge``, so the displacement between them is
+    always parallel to ``edge``; its component along ``edge`` carries the sign
+    that ``.norm()`` throws away.
+    """
+    edge = F.normalize(edge.to(torch.get_default_dtype()), p=2, dim=-1)
+    boundary = mob.get_boundary_in_direction(edge)
+    border = mob.scene.camera.project_point_onto_screen_border(boundary, edge)
+    return float(((border - boundary) * edge).sum(-1).reshape(-1)[0])
+
+
+@pytest.mark.parametrize("edge_name", sorted(EDGES))
+def test_move_to_edge_insets_a_mob_that_starts_inside(edge_name):
+    edge = EDGES[edge_name]
+    mob = Square().move_to_edge(edge)
+
+    assert _signed_inset(mob, edge) == pytest.approx(_buffer(), abs=2e-5)
+
+
+@pytest.mark.parametrize("edge_name", sorted(EDGES))
+def test_move_to_edge_brings_back_a_mob_that_starts_outside(edge_name):
+    # Well past the border to begin with. This used to come to rest ``buffer``
+    # *outside* the border -- still off-screen -- because the inset direction
+    # flipped with the Mob's position.
+    edge = EDGES[edge_name]
+    mob = Square().move(edge * 8).move_to_edge(edge)
+
+    assert _signed_inset(mob, edge) == pytest.approx(_buffer(), abs=2e-5)
+
+
+@pytest.mark.parametrize("edge_name", sorted(EDGES))
+def test_move_to_edge_insets_a_boundary_resting_exactly_on_the_border(edge_name):
+    # Put the boundary on the border, which is the degenerate case: the old
+    # direction term was a zero vector normalized into noise.
+    edge = EDGES[edge_name]
+    mob = Square()
+    boundary = mob.get_boundary_in_direction(edge)
+    border = mob.scene.camera.project_point_onto_screen_border(boundary, edge)
+    mob.move(border - boundary)
+    assert _signed_inset(mob, edge) == pytest.approx(0.0, abs=1e-4)
+
+    mob.move_to_edge(edge)
+
+    assert _signed_inset(mob, edge) == pytest.approx(_buffer(), abs=2e-5)
+
+
+@pytest.mark.parametrize("edge_name", sorted(EDGES))
+def test_move_to_edge_is_idempotent(edge_name):
+    edge = EDGES[edge_name]
+    mob = Square().move_to_edge(edge)
+    once = mob.get_center().reshape(-1, 3)[0].clone()
+
+    mob.move_to_edge(edge)
+
+    torch.testing.assert_close(
+        mob.get_center().reshape(-1, 3)[0], once, atol=2e-5, rtol=0
+    )
+
+
+def test_move_to_corner_insets_both_edges_from_outside():
+    mob = Square().move(UP * 8 + RIGHT * 12).move_to_corner(UP, RIGHT)
+
+    assert _signed_inset(mob, UP) == pytest.approx(_buffer(), abs=2e-5)
+    assert _signed_inset(mob, RIGHT) == pytest.approx(_buffer(), abs=2e-5)
+
+
+@pytest.mark.parametrize("edge_name", sorted(EDGES))
+def test_move_to_edge_leaves_the_other_axes_alone(edge_name):
+    edge = EDGES[edge_name]
+    mob = Square().move(UP * 0.4 + RIGHT * 0.3)
+    start = mob.get_center().reshape(-1, 3)[0].clone()
+
+    mob.move_to_edge(edge)
+
+    off_axis = edge.abs().reshape(-1) < 0.5
+    torch.testing.assert_close(
+        mob.get_center().reshape(-1, 3)[0][off_axis], start[off_axis], atol=2e-5, rtol=0
+    )

--- a/tests/unit_tests/test_surface_parametric_ranges.py
+++ b/tests/unit_tests/test_surface_parametric_ranges.py
@@ -1,0 +1,201 @@
+"""``u_range`` / ``v_range`` on the Manim-parity curved shapes.
+
+Two things are under test, and the second matters as much as the first. The
+ranges must actually restrict the geometry -- they were accepted and stored but
+never read by ``Sphere`` and ``Cylinder``, so a partial range silently built a
+whole shape. And the *default* ranges must reproduce the sampling those shapes
+had before the ranges were honoured, vertex for vertex: every committed render
+baseline is a photograph of that grid, and a rounding difference in the
+longitude lerp would move pixels in scenes that never mention a range.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from algan.constants.math import PI
+from algan.mobs.shapes_3d import Cylinder, Sphere
+from algan.scene_manager import SceneManager
+
+
+@pytest.fixture(autouse=True)
+def reset_scene():
+    SceneManager.reset()
+    yield
+    SceneManager.reset()
+
+
+def _legacy_sphere_coords(uv: torch.Tensor, radius: float) -> torch.Tensor:
+    """``Sphere.coord_function`` exactly as it read before ranges were honoured."""
+    x = uv[..., 0]
+    y = uv[..., 1]
+    longitude = -math.pi * (1 - x) + x * math.pi
+    latitude = -math.pi * 0.5 * (1 - y) + y * math.pi * 0.5
+    coords = torch.stack(
+        (
+            torch.cos(latitude) * torch.cos(longitude),
+            torch.sin(latitude),
+            torch.cos(latitude) * torch.sin(longitude),
+        ),
+        dim=-1,
+    )
+    return coords * radius
+
+
+def _legacy_cylinder_coords(mob: Cylinder, uv: torch.Tensor) -> torch.Tensor:
+    """``Cylinder.coord_function`` exactly as it read before ranges were honoured."""
+    uv = uv.clone()
+    uv[..., 1:] /= uv[..., 1:].amax()
+    u = -uv[..., :1]
+    v = uv[..., 1:]
+    return (
+        (u * math.pi * 2).sin() * mob.radius * mob.get_right_basis()
+        + (v - 0.5) * mob.height * mob.get_upwards_basis()
+        + (u * math.pi * 2).cos() * mob.radius * mob.get_forward_basis()
+    )
+
+
+@pytest.mark.parametrize("radius", [1, 0.8, 2])
+def test_default_sphere_grid_is_bit_identical_to_the_legacy_sampling(radius):
+    sphere = Sphere(radius=radius, add_to_scene=False)
+    base_grid = sphere.get_base_grid().clone()
+
+    produced = sphere.coord_function(base_grid.clone())
+    expected = _legacy_sphere_coords(base_grid, radius)
+
+    assert torch.equal(produced, expected)
+
+
+def test_explicit_default_sphere_ranges_are_bit_identical_to_omitting_them():
+    implicit = Sphere(add_to_scene=False)
+    explicit = Sphere(u_range=(0, 2 * PI), v_range=(0, PI), add_to_scene=False)
+
+    assert (implicit.grid_width, implicit.grid_height) == (
+        explicit.grid_width,
+        explicit.grid_height,
+    )
+    assert torch.equal(implicit.grid.location, explicit.grid.location)
+
+
+@pytest.mark.parametrize(("radius", "height"), [(1, 1), (0.4, 1.6)])
+def test_default_cylinder_grid_is_bit_identical_to_the_legacy_sampling(radius, height):
+    cylinder = Cylinder(radius=radius, height=height, add_to_scene=False)
+    base_grid = cylinder.get_base_grid().clone()
+
+    produced = cylinder.coord_function(base_grid.clone())
+    expected = _legacy_cylinder_coords(cylinder, base_grid)
+
+    assert torch.equal(produced, expected)
+
+
+def test_explicit_default_cylinder_range_is_bit_identical_to_omitting_it():
+    implicit = Cylinder(add_to_scene=False)
+    explicit = Cylinder(v_range=(0, 2 * PI), add_to_scene=False)
+
+    assert (implicit.grid_width, implicit.grid_height) == (
+        explicit.grid_width,
+        explicit.grid_height,
+    )
+    assert torch.equal(implicit.grid.location, explicit.grid.location)
+
+
+def _extents(mob):
+    points = mob.grid.location.detach().reshape(-1, 3)
+    return points.amin(dim=0), points.amax(dim=0)
+
+
+def test_sphere_u_range_restricts_the_azimuth_to_the_out_half():
+    # ``u`` starts at LEFT and turns through OUT, so half of it is the half
+    # facing the camera: OUT is -z, and no vertex may cross into +z.
+    low, high = _extents(Sphere(u_range=(0, PI), add_to_scene=False).spawn())
+
+    assert high[2] <= 1e-6
+    assert low[2] < -0.99
+    # The azimuth is cut, not the poles: full height and full width survive.
+    assert low[1] == pytest.approx(-1, abs=1e-5)
+    assert high[1] == pytest.approx(1, abs=1e-5)
+    assert low[0] < -0.99
+    assert high[0] > 0.99
+
+
+def test_sphere_u_range_second_half_is_the_in_half():
+    low, high = _extents(Sphere(u_range=(PI, 2 * PI), add_to_scene=False).spawn())
+
+    assert low[2] >= -1e-6
+    assert high[2] > 0.99
+
+
+def test_sphere_v_range_runs_pole_to_pole():
+    bottom_low, bottom_high = _extents(
+        Sphere(v_range=(0, PI / 2), add_to_scene=False).spawn()
+    )
+    top_low, top_high = _extents(
+        Sphere(v_range=(PI / 2, PI), add_to_scene=False).spawn()
+    )
+
+    # v = 0 is the DOWN pole and v = PI the UP one.
+    assert bottom_low[1] == pytest.approx(-1, abs=1e-5)
+    assert bottom_high[1] <= 1e-6
+    assert top_low[1] >= -1e-6
+    assert top_high[1] == pytest.approx(1, abs=1e-5)
+
+
+def test_partial_sphere_vertices_all_lie_on_the_sphere():
+    sphere = Sphere(
+        radius=0.7,
+        u_range=(0, PI / 2),
+        v_range=(PI / 4, 3 * PI / 4),
+        add_to_scene=False,
+    ).spawn()
+
+    radii = sphere.grid.location.detach().reshape(-1, 3).norm(dim=-1)
+
+    assert torch.allclose(radii, torch.full_like(radii, 0.7), atol=1e-5)
+
+
+def test_cylinder_v_range_restricts_the_azimuth_to_the_left_half():
+    low, high = _extents(Cylinder(v_range=(0, PI), add_to_scene=False).spawn())
+
+    assert high[0] <= 1e-6
+    assert low[0] < -0.99
+    # The cut runs the length of the tube, so the axial extent is untouched.
+    assert low[1] == pytest.approx(-0.5, abs=1e-5)
+    assert high[1] == pytest.approx(0.5, abs=1e-5)
+
+
+def test_cylinder_v_range_second_half_is_the_right_half():
+    low, high = _extents(Cylinder(v_range=(PI, 2 * PI), add_to_scene=False).spawn())
+
+    assert low[0] >= -1e-6
+    assert high[0] > 0.99
+
+
+def test_partial_cylinder_vertices_all_lie_on_the_cylinder():
+    cylinder = Cylinder(radius=0.6, v_range=(0, PI / 2), add_to_scene=False).spawn()
+
+    points = cylinder.grid.location.detach().reshape(-1, 3)
+    radii = points[:, [0, 2]].norm(dim=-1)
+
+    assert torch.allclose(radii, torch.full_like(radii, 0.6), atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    ("factory", "kwargs"),
+    [
+        (Sphere, {"u_range": (0, PI)}),
+        (Sphere, {"v_range": (0, PI / 2)}),
+        (Cylinder, {"v_range": (0, PI)}),
+    ],
+)
+def test_a_partial_range_no_longer_reproduces_the_whole_shape(factory, kwargs):
+    # The defect this file exists for: the ranges used to be stored and never
+    # read, so a partial shape came out with the extents of the whole one.
+    whole_low, whole_high = _extents(factory(add_to_scene=False).spawn())
+    partial_low, partial_high = _extents(factory(add_to_scene=False, **kwargs).spawn())
+
+    assert not torch.allclose(whole_low, partial_low, atol=1e-4) or not torch.allclose(
+        whole_high, partial_high, atol=1e-4
+    )


### PR DESCRIPTION
## What and why

Closes the three items left open by the docs audit (#31), plus one bug that fell out of checking a claim I had written.

**`Sphere`'s `u_range`/`v_range` and `Cylinder`'s `v_range` now restrict the geometry.** They were accepted, stored, and never read: `coord_function` swept the whole domain regardless, so `Sphere(u_range=(0, PI))` built a whole sphere with the extents of one. The audit left this alone because making it work looked like a re-baselining job, and `Sphere.coord_function` carries a comment saying its sampling orientation is deliberate. It does not have to be. The ranges are folded into the *endpoints* of each shape's existing interpolation rather than applied on top of it, so at the default domains the arithmetic reduces to the previous expression term for term and nothing moves.

Which parameter is which follows Manim: `Sphere`'s `u_range` is the azimuth and its `v_range` runs pole to pole; `Cylinder`'s `v_range` is the azimuth about the axis, with the axial extent coming from `height`, as it does in Manim. The zero of each sweep is Algan's own seam rather than Manim's, so a half shape comes out rotated relative to Manim's — the docstrings say where each one starts.

**The text constructors are documented.** `Tex`'s constructor prose moves out of `__init__` into the class docstring, and `Tex`, `Text` and `MarkupText` now document every parameter in their signature with its default (`Text` documented 2 of 21). `MathTex` and `Title` are generated Manim-compatibility wrappers that inherited Manim's class docstring verbatim, which put a `.. manim::` block — a Manim scene, executed and rendered at build time — on an Algan reference page, teaching a script that will not run here. They get Algan-authored docstrings instead.

**`move_to_edge` takes its inset direction from the edge argument.** It computed `border + normalize(boundary - border) * buffer`, reading the direction off where the Mob currently is rather than off the edge it was asked to move to. The border is cast *from* the boundary *along* the edge, so that difference is antiparallel to the edge only while the Mob is inside the frame. A Mob already past the edge came to rest `buffer` *outside* the border — still off-screen — so the method was not idempotent and could not recover a Mob that had left the frame. And a boundary resting exactly *on* the border made the difference zero, leaving `F.normalize` to amplify float32 noise into a whole unit vector, so rounding chose the direction.

Two things surfaced while checking claims and are documented rather than fixed, both being behaviour changes rather than docs:

- `MarkupText` strips its markup unconditionally, not only when Pango is unavailable as its docstring claimed. Measured: a `<span foreground='red'>` leaves every glyph white.
- A `Title` places itself against *Manim's* frame. Manim's is 8 units tall and its `to_edge` leaves 0.5, putting the title's top at `y = 3.5` — exactly where Algan's camera puts its top border. Nothing is cut off, but it sits flush against the frame edge with no margin. This is what led to the `move_to_edge` bug: a `Title` lands on the degenerate case deterministically.

The audit's remaining lint item needed no change. The unused `TriangleTriangulated` import in `surfaces/surface.py` went away in b49b01b, `ruff check` is F401-clean repo-wide, and the name is still exported — from `shapes_2d`, where it is defined, which was the concern behind leaving it alone.

## Rendered output

**Unchanged.** `pytest -q tests/full_renders` passes 7/7 against the committed CPU baselines on this machine — every scene exact, nothing re-baselined. Worth flagging for whoever reviews: the audit reported three of those scenes failing by ~200 channel values on *its* machine, and they all pass here, so the two boxes disagree about which committed baselines are authoritative. That is the per-machine `fast_math` tessellation story `CLAUDE.md` documents, not something this branch causes.

Two independent checks back that up, because `tests/full_renders` alone would not isolate this change:

- A before/after A/B of the default `Sphere`, `Cylinder`, `Cone` and `Torus` grids is bit-identical under `torch.equal`. `tests/unit_tests/test_surface_parametric_ranges.py` pins that permanently by checking `coord_function` against the pre-change formula, so a later edit cannot move a baseline unnoticed.
- For `move_to_edge`, the new target is *bitwise identical* to the old one for every axis-aligned edge whenever the Mob starts inside the frame, which is the only case any existing scene exercises — normalizing a vector with a single nonzero component yields exactly ±1, so the two expressions agree to the last bit. Verified with `torch.equal` on UP/DOWN/LEFT/RIGHT for a `Square` and a `Text`. Only the two broken cases move, by exactly `2 * buffer`. No pixel-compared scene reaches the code at all: neither `tests/fast/scene.py` nor any `tests/full_renders` scene calls `move_to_edge` or `move_to_corner`.

A caveat on the second one: a *diagonal* edge could see a sub-ULP difference, since normalizing a multi-component vector is not exact. The new value is the correct one there regardless.

## Verification

All on a CPU-only cloud session (no GPU):

- `pytest -q --fast` — 211 passed, 24s of its 75s budget. That is the third consecutive run; runs 1 and 2 reported 126s and 87s while paying cold Taichi compiles, as `CLAUDE.md` warns.
- `pytest -q tests/unit_tests tests/fast` — 1118 passed, 91 skipped.
- `pytest -q tests/full_renders` — 7 passed.
- `ruff check --no-fix` and `ruff format --check` — clean.
- `docs/make_and_open_docs.py --skip-examples --no-open` — builds, one pre-existing warning (`graphviz` `dot` is not installed in this container).
- Every new `.. algan::` example was executed and its rendered frame checked for ink inside the frame, not merely for the absence of an exception. Docstring examples are not covered by `test_doc_examples.py`, which scans `docs/source/*.rst` only.

**Not checked here: CUDA.** No GPU on this machine, so CUDA behaviour and any CPU/CUDA divergence are unverified, and `expected_outputs_cuda/` was not touched. Nothing in the diff is expected to need it, since default-range output is bit-identical, but that is an argument rather than a measurement.

The 21 new `move_to_edge` tests use a *signed* inset. The existing coverage in `test_manim_compat_movement.py` measures the gap with `.norm()`, and an unsigned gap cannot tell 0.6 inside from 0.6 outside — which is how both failure modes survived. Seven of the new tests fail on the old code; the degenerate case fails for only two of the four edges there, which is the arbitrary sign demonstrating itself.

## Docs

- `Sphere` and `Cylinder`: `u_range`/`v_range` entries rewritten with units, defaults and where each sweep starts, plus a `Notes` section on partial ranges building an open shell and being re-tessellated from scratch (a partial shape is not automatically the cheaper one). New `:save_last_frame:` examples for both.
- `Tex`, `Text`, `MarkupText`, `MathTex`, `Title`: class docstrings per `DOCSTRINGS.md` §10 — full `Parameters`, `Animation` sections, `Attributes`, and runnable examples.
- `move_to_edge`: its docstring now states that the boundary comes to rest `buffer` *inside* the border regardless of where the Mob starts, and that the call is idempotent.
- `docs/source/manim_user_quickstart/migrating_from_manim.rst`: the radians list no longer says `Sphere` and `Cylinder` ignore their ranges; the text section gains which LaTeX name is native vs compatibility, and the frame-size mismatch behind `Title`.
- `DOCSTRINGS.md` §15: step 3 recorded as done in both halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0174YAB3WPqmQgJnS1YeAxZp)_