### PR TITLE
Give a Surface's texels their world positions

### DIFF
--- a/algan/constants/color.py
+++ b/algan/constants/color.py
@@ -27,7 +27,7 @@ import re
 import torch
 
 from algan.settings._startup import _ANIMATION_DEVICE
-from algan.utils.tensor_utils import broadcast, cast_to_tensor
+from algan.utils.tensor_utils import broadcast, cast_to_tensor, unsqueeze_left
 
 re_hex = re.compile("((?<=#)|(?<=0x))[A-F0-9]{6,8}", re.IGNORECASE)
 
@@ -108,6 +108,14 @@ class Color(torch.Tensor):
         value = cast_to_tensor(value)
         out = self.new_empty()
         out.data = self.data.clone()
+        # A named colour is a single ``[5]`` row, so painting a grid of values
+        # onto it -- one per vertex, one per texel -- has nothing to broadcast
+        # against until the leading axes exist. Give it the value's, but only
+        # when the value really carries a grid: a scalar opacity arrives padded
+        # to ``[1, 1, 1]``, and inflating a named colour to match it would
+        # change the shape every existing caller gets back.
+        if any(size > 1 for size in value.shape[:-1]):
+            out = unsqueeze_left(out, value)
         out = broadcast(out, value, [-1]).contiguous()
         return out
 

--- a/algan/mobs/surfaces/surface.py
+++ b/algan/mobs/surfaces/surface.py
@@ -46,6 +46,7 @@ from algan.geometry.geometry import (
 )
 from algan.rendering.logical_pn import (
     evaluate_logical_pn,
+    evaluate_logical_pn_per_patch,
     logical_pn_control_points,
 )
 from algan.utils.file_utils import get_image
@@ -112,6 +113,11 @@ _PROJECTION_BOX_CELLS = 2.0
 # walk the step back down costs one iteration per rejection. All scales are
 # evaluated in one batch instead, so each iteration lands on the best of them.
 _PROJECTION_SCALES = (1.0, 0.5, 0.25, 0.1, 0.03, 0.01)
+
+# How many texels ``Surface.get_texture_locations`` resolves at a time. Every
+# texel carries ten intermediate PN control points, so a 4K map evaluated in one
+# go would want gigabytes; this bounds it to tens of megabytes regardless.
+_TEXTURE_LOCATION_CHUNK_TEXELS = 1 << 18
 
 
 def _call_parametric_function(function, u, v):
@@ -3045,6 +3051,207 @@ class Surface(Mob):
             self._cached_base_grid = grid
             self._cached_base_grid_key = cache_key
         return self._cached_base_grid
+
+    def _surface_points_at(self, u, v, grid, normals):
+        """World positions of the parameter lattice ``u`` x ``v`` on the mesh.
+
+        ``u`` and ``v`` are 1-D tensors in ``[0, 1]``, ``grid`` is
+        ``[..., grid_width, grid_height, 3]`` and ``normals`` its vertex
+        normals; the result is ``[..., len(u), len(v), 3]``.
+
+        This reproduces what the renderer does with a UV coordinate, which is
+        the only reason it is not simply ``coord_function(uv)``: the kernel
+        interpolates the triangle corners' UVs barycentrically and the geometry
+        under them is the logical PN patch, so a point's position is that patch
+        evaluated at the barycentric coordinate -- not the analytic surface at
+        the same parameter. The two differ tangentially by a fixed fraction of
+        a grid cell (~12% on a stock Sphere), which is what would otherwise
+        scallop a colour boundary once the texture out-resolves the grid.
+        """
+        width, height = self.grid_width, self.grid_height
+        fu = (u.clamp(0, 1) * (width - 1)).view(-1, 1)
+        fv = (v.clamp(0, 1) * (height - 1)).view(1, -1)
+        i = fu.floor().clamp(0, width - 2)
+        j = fv.floor().clamp(0, height - 2)
+        s = fu - i
+        t = fv - j
+        i = i.long().expand(-1, v.shape[0])
+        j = j.long().expand(u.shape[0], -1)
+
+        # get_grid_to_triangle_indices splits every cell into t1 = (00, 01, 10)
+        # and t2 = (10, 01, 11); the diagonal between them is s + t == 1.
+        lower = (s + t) <= 1.0
+        pick = lower.unsqueeze(-1)
+
+        def corners_of(field):
+            return torch.stack(
+                (
+                    torch.where(pick, field[..., i, j, :], field[..., i + 1, j, :]),
+                    field[..., i, j + 1, :],
+                    torch.where(
+                        pick, field[..., i + 1, j, :], field[..., i + 1, j + 1, :]
+                    ),
+                ),
+                -2,
+            )
+
+        # Barycentric weights of (s, t) in whichever triangle contains it, in
+        # the (corner 1, corner 2) form the PN evaluator takes.
+        barycentric = torch.stack(
+            (
+                torch.where(lower, t, 1 - s),
+                torch.where(lower, s, s + t - 1),
+            ),
+            -1,
+        )
+        return evaluate_logical_pn_per_patch(
+            logical_pn_control_points(corners_of(grid), corners_of(normals)),
+            barycentric,
+        )
+
+    def get_texture_locations(
+        self, resolution: int | tuple[int, int] | None = None
+    ) -> torch.Tensor:
+        """Get where in the world each texel of this surface's texture maps sits.
+
+        Textures are addressed in the surface's own ``(u, v)`` coordinates, which
+        makes a map easy to write in terms of the surface's parameters and awkward
+        to write in terms of *space*. This is the bridge: it hands back the world
+        position of every texel, laid out exactly like a texture map, so a map can
+        be built from arithmetic on 3-D coordinates.
+
+        .. code-block:: python
+
+            xyz = surface.get_texture_locations()
+            surface.color_texture = WHITE.mult_opacity(xyz[..., 1:2])
+
+        The positions are read from the surface's current mesh, so they are right
+        whether the shape came from its coordinate function, from a deformation,
+        or from writing ``surface.grid.location`` yourself. They describe the
+        surface *now*: a texture is carried in ``(u, v)``, so colours derived from
+        world position travel with the surface when it later moves. Recompute them
+        in an :meth:`~algan.animatable_base.animatable.Animatable.add_updater`
+        callback for a texture that stays locked to world space.
+
+        Animation
+        ---------
+        A query, not a change: nothing is recorded and the surface is untouched.
+        The positions are those of the surface's current state, so call it after
+        the transforms you want reflected in it.
+
+        Parameters
+        ----------
+        resolution
+            Texel counts ``(W, H)`` along ``u`` and ``v``, or one int for a square
+            map. Defaults to ``None``, meaning the resolution of the surface's
+            current :attr:`color_texture`, or its grid resolution when it has no
+            texture yet. Pass the resolution explicitly to build a map for one of
+            the material texture arguments instead.
+
+        Returns
+        -------
+        torch.Tensor
+            World-space positions, shape ``[W, H, 3]`` -- the layout
+            :attr:`color_texture` takes, one row per texel of the map that will
+            be sampled there. Called where the surface's state spans several
+            frames (inside an updater), it keeps a leading frame axis,
+            ``[F, W, H, 3]``.
+
+        Raises
+        ------
+        ValueError
+            If this is a packed surface built by
+            :meth:`~algan.mobs.surfaces.surface.Surface.from_batches`, whose
+            members share one texture and therefore have no single answer; if the
+            grid has fewer than two points on an axis, so it has no triangles to
+            sit on; or if ``resolution`` is not positive on both axes.
+
+        See Also
+        --------
+        :meth:`~algan.mobs.surfaces.surface.Surface.get_base_grid`
+            The ``(u, v)`` domain these positions correspond to.
+        :meth:`~algan.mobs.surfaces.surface.Surface.set_color_by_function`
+            Colour the surface's vertices by ``(u, v)`` instead.
+
+        Examples
+        --------
+        Paint a sphere's northern half, cutting the boundary in world space
+        rather than along a parameter line:
+
+        .. algan:: Example1SurfaceGetTextureLocations
+            :save_last_frame:
+
+            from algan import *
+
+            globe = Sphere(radius=1.5)
+            height = globe.get_texture_locations((128, 128))[..., 1:2]
+            globe.color_texture = BLUE.mult_opacity((height > 0).float())
+            globe.spawn()
+
+            Scene.save_video()
+        """
+        if self._packed_grid_count() is not None:
+            raise ValueError(
+                "get_texture_locations is not defined for a packed surface: the "
+                "members built by from_batches share one texture, so a texel "
+                "has one position per member. Build the members separately to "
+                "texture them by world position."
+            )
+        if self.grid_width < 2 or self.grid_height < 2:
+            raise ValueError(
+                "get_texture_locations needs at least 2 grid points on each "
+                f"axis, got grid_width={self.grid_width}, "
+                f"grid_height={self.grid_height}"
+            )
+
+        if resolution is None:
+            if self._has_color_texture:
+                # texture_height / texture_width are the u / v axis lengths, in
+                # that order -- the names are inverted with respect to the
+                # public [W, H, 5] contract, the axes are not.
+                resolution = (self.texture_height, self.texture_width)
+            else:
+                resolution = (self.grid_width, self.grid_height)
+        if isinstance(resolution, (tuple, list)):
+            width, height = int(resolution[0]), int(resolution[1])
+        else:
+            width = height = int(resolution)
+        if width < 1 or height < 1:
+            raise ValueError(
+                f"resolution must be positive on both axes, got {(width, height)}"
+            )
+
+        grid = self._reshape_grid_for_render(self.grid.location)
+        # The renderer builds its PN patches from these same normals, and
+        # ignore_normals leaves it without any: zero normals collapse the patch
+        # onto the flat triangle, which is then exactly what is drawn.
+        normals = (
+            torch.zeros_like(grid)
+            if self.ignore_normals
+            else compute_grid_vertex_normals(grid)
+        )
+
+        # A closed axis is wrap-padded at render time, putting texel i at
+        # i / W rather than i / (W - 1) (see wrap_pad_texture).
+        closed_u, closed_v = surface_closed_axes(grid)
+        u = torch.arange(width, device=grid.device, dtype=grid.dtype) / (
+            width if closed_u and width > 1 else max(width - 1, 1)
+        )
+        v = torch.arange(height, device=grid.device, dtype=grid.dtype) / (
+            height if closed_v and height > 1 else max(height - 1, 1)
+        )
+
+        rows = max(1, _TEXTURE_LOCATION_CHUNK_TEXELS // height)
+        locations = torch.cat(
+            [
+                self._surface_points_at(u[start : start + rows], v, grid, normals)
+                for start in range(0, width, rows)
+            ],
+            -3,
+        )
+        # The grid carries a leading frame axis, which is a single frame in
+        # every case but a query made mid-materialization.
+        return locations[0] if locations.shape[0] == 1 else locations
 
     def set_shape_to(self, other_surface: Surface):
         """Changes this surface's shape to the shape defined by another surface's

--- a/algan/rendering/logical_pn.py
+++ b/algan/rendering/logical_pn.py
@@ -238,6 +238,45 @@ def evaluate_logical_pn(control_points, uv):
     )
 
 
+def evaluate_logical_pn_per_patch(control_points, uv):
+    """Evaluate cubic logical PN position patches, one ``uv`` per patch.
+
+    :func:`evaluate_logical_pn` evaluates every patch at every coordinate,
+    which is what dicing wants: one subdivision pattern shared by the whole
+    mesh. This instead pairs each patch with its own coordinate, for callers
+    that already know which patch a point falls in -- looking up where a texel
+    sits on the surface, say.
+
+    Parameters
+    ----------
+    control_points
+        Tensor ``[..., 10, 3]``.
+    uv
+        Tensor ``[..., 2]`` in the barycentric ``(u, v)`` domain, broadcasting
+        against ``control_points``' leading dimensions.
+
+    Returns
+    -------
+    Tensor
+        Shape ``[..., 3]``.
+    """
+    u = uv[..., :1]
+    v = uv[..., 1:]
+    w = 1.0 - u - v
+    return (
+        (w * w * w) * control_points[..., 0, :]
+        + (u * u * u) * control_points[..., 1, :]
+        + (v * v * v) * control_points[..., 2, :]
+        + (3.0 * w * w * u) * control_points[..., 3, :]
+        + (3.0 * w * u * u) * control_points[..., 4, :]
+        + (3.0 * u * u * v) * control_points[..., 5, :]
+        + (3.0 * u * v * v) * control_points[..., 6, :]
+        + (3.0 * w * v * v) * control_points[..., 7, :]
+        + (3.0 * w * w * v) * control_points[..., 8, :]
+        + (6.0 * w * u * v) * control_points[..., 9, :]
+    )
+
+
 def evaluate_logical_pn_normals(control_points, uv):
     """Evaluate and normalize quadratic logical PN normal patches."""
     extra_dims = uv.ndim - 1

--- a/docs/source/advanced_user_tutorials/images_and_textures.rst
+++ b/docs/source/advanced_user_tutorials/images_and_textures.rst
@@ -171,6 +171,52 @@ An **open** surface -- a flat plane, an :class:`~.ImageMob`, the pole-to-pole
 ``v`` axis of a sphere -- has no far side to blend into, so its first and last
 texels sit exactly on its two edges and the edge value carries beyond them.
 
+Building a map from world positions
+-----------------------------------
+
+A texture is written in ``(u, v)``, which is the wrong language for a map whose
+content depends on *where the surface is*: "everything above the equator",
+"redder the further from the origin". :meth:`~algan.mobs.surfaces.surface.Surface.get_texture_locations`
+translates -- it hands back the world position of every texel, laid out exactly
+like the map itself, so the map can be written as arithmetic on 3-D coordinates:
+
+.. algan:: TexturesByWorldPosition
+    :save_last_frame:
+
+    from algan import *
+
+    globe = Sphere(radius=1.5)
+    xyz = globe.get_texture_locations((256, 256))
+    globe.color_texture = BLUE.mult_opacity((xyz[..., 1:2] > 0).float())
+    globe.spawn()
+
+    Scene.save_video()
+
+The positions come from the surface's **current mesh**, not from its coordinate
+function, so they are right for a shape that has been deformed, morphed with
+:meth:`~algan.mobs.surfaces.surface.Surface.set_shape_to`, or built by assigning
+``surface.grid.location`` directly. They also account for the wrapping above and
+for the curvature between grid vertices, which is what keeps a boundary like the
+one in that example straight rather than scalloped once the map out-resolves the
+grid.
+
+The ``resolution`` argument is what sizes a map that does not exist yet, as
+above. Leave it out once the surface has a ``color_texture`` and you get that
+texture's resolution; the material maps are constructor arguments, so size those
+from a surface of the same shape:
+
+.. code-block:: python
+
+    probe = Sphere(radius=1.5)
+    height = probe.get_texture_locations((128, 128))[..., 1:2]
+    sphere = Sphere(radius=1.5, roughness_texture=(height / 1.5).clamp(0, 1))
+
+Because a texture is carried in ``(u, v)``, colours derived this way travel with
+the surface when it later moves: they record where it *was* when you asked. Take
+the positions again inside an
+:meth:`~algan.animatable_base.animatable.Animatable.add_updater` callback for a
+texture that stays locked to world space.
+
 Animating a texture
 -------------------
 

--- a/tests/unit_tests/test_color_grid_broadcasting.py
+++ b/tests/unit_tests/test_color_grid_broadcasting.py
@@ -1,0 +1,67 @@
+"""Painting a grid of values onto a named colour.
+
+``WHITE.mult_opacity(values)`` is how you turn a colour into a gradient: one
+opacity per vertex, or per texel, computed from whatever the values mean --
+height above the ground, distance from a point, a field being visualised.
+
+A named colour is a single ``[5]`` row, though, so until the colour has the
+value's leading axes there is nothing for the assignment to land in, and the
+call used to raise ``expand(...): the number of sizes provided (1) must be
+greater or equal to the number of dimensions in the tensor``. :meth:`Color.prep_set`
+now gives the colour those axes -- but only when the value really carries a
+grid, since a scalar opacity arrives padded to ``[1, 1, 1]`` and every existing
+caller of ``WHITE.set_opacity(0.5)`` expects a ``[5]`` colour back.
+
+Feature tests for the colour helpers: unmarked, so outside the fast suite.
+"""
+
+import torch
+
+from algan.constants.color import BLUE, RED, WHITE
+from algan.mobs.shapes_3d import Sphere
+from algan.scene_manager import SceneManager
+
+
+def test_a_named_colour_takes_a_value_per_vertex():
+    SceneManager.reset()
+    sphere = Sphere(radius=1.0)
+    height = sphere.grid.location[..., 1:2]
+
+    colored = WHITE.mult_opacity(height)
+
+    assert colored.shape == (*height.shape[:-1], 5)
+    assert torch.allclose(colored[..., -1:], height)
+    sphere.grid.color = colored
+
+
+def test_a_named_colour_takes_a_value_per_texel():
+    """The same call with a texture-shaped value, which is what makes a map
+    buildable from :meth:`~.Surface.get_texture_locations`.
+    """
+    values = torch.rand(16, 12, 1)
+
+    colored = BLUE.mult_opacity(values)
+
+    assert colored.shape == (16, 12, 5)
+    assert torch.allclose(colored[..., -1:], values)
+    assert torch.allclose(colored[..., :3], BLUE[:3].expand(16, 12, 3))
+
+
+def test_a_scalar_still_gives_back_a_single_colour():
+    """The shape every existing caller gets: broadening the grid case must not
+    inflate this one.
+    """
+    assert WHITE.set_opacity(0.5).shape == (5,)
+    assert WHITE.mult_opacity(0.5).shape == (5,)
+    assert WHITE.set_glow(0.3).shape == (5,)
+    assert RED.set_rgb(torch.rand(3)).shape == (5,)
+
+
+def test_a_colour_that_already_has_axes_keeps_them():
+    SceneManager.reset()
+    sphere = Sphere(radius=1.0)
+    height = sphere.grid.location[..., 1:2]
+
+    colored = sphere.grid.color.mult_opacity(height)
+
+    assert colored.shape == sphere.grid.color.shape

--- a/tests/unit_tests/test_surface_texture_locations.py
+++ b/tests/unit_tests/test_surface_texture_locations.py
@@ -1,0 +1,282 @@
+"""Where a texel sits in the world, for textures written in terms of space.
+
+A texture is addressed in ``(u, v)``, so a map whose content depends on world
+position -- "colour everything above the equator" -- has no natural way to be
+written. :meth:`~.Surface.get_texture_locations` supplies the missing half: the
+world position of every texel, laid out like the map itself.
+
+The position it must report is the one the renderer will draw the texel at, and
+that is *not* ``coord_function(u, v)``. The kernel interpolates the triangle
+corners' UVs barycentrically and the geometry beneath them is the logical PN
+patch, so a texel lands on that patch at the barycentric coordinate its UV
+resolves to. On a stock ``Sphere`` the two answers differ tangentially by ~12%
+of a grid cell -- invisible on a small map, a scalloped boundary on a large one.
+Reading the mesh instead also means the answer survives a grid the coordinate
+function no longer describes, which is most of why it is worth having.
+
+These tests pin that: the reported positions sit on the drawn surface, agree
+with a reference implementation built from the renderer's own triangle list,
+honour the wrap-padding convention on closed axes, and track a grid written by
+hand.
+
+Feature tests for the texture path: unmarked, so outside the fast suite.
+"""
+
+import pytest
+import torch
+
+from algan.constants.spatial import RIGHT
+from algan.mobs.shapes_3d import Sphere, Torus
+from algan.mobs.surfaces import surface as surface_module
+from algan.mobs.surfaces.surface import (
+    Surface,
+    compute_grid_vertex_normals,
+    grid_to_triangle_vertices,
+)
+from algan.rendering.logical_pn import (
+    evaluate_logical_pn,
+    logical_pn_control_points,
+)
+from algan.scene_manager import SceneManager
+
+
+def _mesh(surface):
+    """The surface's current vertex grid, ``[W, H, 3]``."""
+    return surface._reshape_grid_for_render(surface.grid.location)[0]
+
+
+def _renderer_position(surface, u, v):
+    """Where the renderer puts UV ``(u, v)``, from its own triangle list.
+
+    The slow, obvious implementation of what ``get_texture_locations`` computes
+    in closed form: gather the triangles exactly as ``_build_render_primitive``
+    does, find the one whose UV triangle contains the coordinate, and evaluate
+    its PN patch at the barycentric weights that lands on.
+    """
+    grid = _mesh(surface)
+    normals = compute_grid_vertex_normals(grid)
+    triangle_uvs = grid_to_triangle_vertices(surface.get_base_grid()).reshape(-1, 3, 2)
+    controls = logical_pn_control_points(
+        grid_to_triangle_vertices(grid).reshape(-1, 3, 3),
+        grid_to_triangle_vertices(normals).reshape(-1, 3, 3),
+    )
+
+    a, b, c = triangle_uvs.unbind(-2)
+    edge_1, edge_2 = b - a, c - a
+    point = torch.tensor([u, v]) - a
+    denominator = edge_1[:, 0] * edge_2[:, 1] - edge_2[:, 0] * edge_1[:, 1]
+    weight_1 = (point[:, 0] * edge_2[:, 1] - edge_2[:, 0] * point[:, 1]) / denominator
+    weight_2 = (edge_1[:, 0] * point[:, 1] - point[:, 0] * edge_1[:, 1]) / denominator
+    inside = (
+        (weight_1 >= -1e-6) & (weight_2 >= -1e-6) & (weight_1 + weight_2 <= 1e-6 + 1)
+    )
+    index = int(inside.nonzero()[0])
+    barycentric = torch.stack((weight_1[index], weight_2[index])).view(1, 2)
+    return evaluate_logical_pn(controls[index : index + 1].unsqueeze(0), barycentric)[
+        0, 0, 0
+    ]
+
+
+def test_every_texel_lands_on_the_surface_it_is_drawn_on():
+    """A sphere's texels must all be a radius from its centre, to within the
+    tolerance the mesh itself was built to.
+    """
+    SceneManager.reset()
+    sphere = Sphere(radius=1.5)
+
+    locations = sphere.get_texture_locations((64, 64))
+
+    assert locations.shape == (64, 64, 3)
+    error = (locations.norm(dim=-1) - 1.5).abs().max()
+    assert error <= sphere.geometry_tolerance, (
+        f"texels stray {error:.5f} off a surface built to {sphere.geometry_tolerance}"
+    )
+
+
+def test_texel_positions_match_the_renderers_own_triangles():
+    """The closed-form cell lookup must agree with a brute-force search over
+    the very triangles the renderer is handed.
+    """
+    SceneManager.reset()
+    sphere = Sphere(radius=1.0)
+    width, height = 32, 24
+    locations = sphere.get_texture_locations((width, height))
+
+    # u is wrap-padded (the sphere closes on it), v is not.
+    for i, j in ((0, 0), (7, 5), (13, 17), (31, 23), (20, 0)):
+        expected = _renderer_position(sphere, i / width, j / (height - 1))
+        assert torch.allclose(locations[i, j], expected, atol=1e-5), (
+            f"texel {(i, j)} disagrees with the triangle the renderer samples it on"
+        )
+
+
+def test_a_flat_surface_reports_its_exact_analytic_positions():
+    """With no curvature to interpolate there is one right answer, and the
+    coordinate function gives it.
+    """
+    SceneManager.reset()
+    plane = Surface(grid_width=5, grid_height=5)
+
+    locations = plane.get_texture_locations((16, 9))
+
+    base = torch.stack(
+        (
+            torch.linspace(0, 1, 16).view(-1, 1).expand(-1, 9),
+            torch.linspace(0, 1, 9).view(1, -1).expand(16, -1),
+        ),
+        -1,
+    )
+    assert torch.allclose(locations, plane.coord_function(base), atol=1e-6)
+
+
+def test_a_closed_axis_leaves_room_for_the_wrap():
+    """Texel ``W-1`` of a closed axis sits one step short of the seam, because
+    the map is wrap-padded before it is sampled -- clamping instead would put
+    it *on* the seam and squash the map by a texel.
+    """
+    SceneManager.reset()
+    sphere = Sphere(radius=1.0)
+    width = 8
+
+    locations = sphere.get_texture_locations((width, 5))
+
+    # One ring of texels, away from the poles where every column coincides.
+    # The steps around it are near-uniform rather than exactly so: 8 texels do
+    # not divide the grid's 19 columns, so each lands at a different point
+    # within its cell. Clamping would make the closing step 0 -- nothing like
+    # a percent away.
+    ring = locations[:, 2]
+    steps = (ring.roll(-1, 0) - ring).norm(dim=-1)
+    assert steps.max() / steps.min() < 1.02, (
+        "the step from the last column back to the first must match every other "
+        f"step around the ring, got {steps.tolist()}"
+    )
+
+    plane = Surface(grid_width=5, grid_height=5)
+    open_axis = plane.get_texture_locations((width, 5))
+    assert torch.allclose(
+        open_axis[0, :, 0], plane.coord_function(torch.zeros(1, 2))[..., 0], atol=1e-6
+    ), "an open axis puts its first texel on the domain edge"
+    assert torch.allclose(
+        open_axis[-1, :, 0],
+        plane.coord_function(torch.tensor([[1.0, 0.0]]))[..., 0],
+        atol=1e-6,
+    ), "and its last texel on the other edge"
+
+
+def test_positions_come_from_the_grid_not_the_coordinate_function():
+    """The case the helper exists for: a grid written by hand leaves
+    ``coord_function`` describing a shape that is no longer there.
+    """
+    SceneManager.reset()
+    sphere = Sphere(radius=1.0)
+    grid = _mesh(sphere)
+    sphere.grid.location = (grid * torch.tensor([1.0, 3.0, 1.0])).reshape(1, -1, 3)
+
+    locations = sphere.get_texture_locations((32, 32))
+
+    assert locations[..., 1].abs().max() > 2.9, (
+        "the stretched grid is the shape that gets drawn, so it is the shape "
+        "the texels sit on"
+    )
+    assert sphere.coord_function(sphere.get_base_grid())[..., 1].abs().max() < 1.1, (
+        "meanwhile the coordinate function still describes the original sphere"
+    )
+
+
+def test_positions_follow_the_surface_when_it_moves():
+    SceneManager.reset()
+    sphere = Sphere(radius=1.0).spawn()
+    before = sphere.get_texture_locations((16, 16))
+
+    sphere.move(RIGHT * 3)
+
+    after = sphere.get_texture_locations((16, 16))
+    assert torch.allclose(after - before, torch.tensor([3.0, 0.0, 0.0]), atol=1e-5)
+
+
+def test_ignoring_normals_reports_the_flat_triangles_that_are_drawn():
+    """``ignore_normals`` leaves the renderer with no vertex normals, so it
+    draws flat triangles; the reported positions have to be flat too.
+    """
+    SceneManager.reset()
+    sphere = Sphere(radius=1.0, ignore_normals=True)
+    grid = _mesh(sphere)
+    width, height = sphere.grid_width, sphere.grid_height
+
+    locations = sphere.get_texture_locations((17, 13))
+
+    # Plain barycentric interpolation over the same two triangles per cell.
+    u = torch.arange(17.0) / 17  # u closes, so it is wrap-padded
+    v = torch.arange(13.0) / 12
+    fu = (u * (width - 1)).view(-1, 1)
+    fv = (v * (height - 1)).view(1, -1)
+    i = fu.floor().clamp(0, width - 2)
+    j = fv.floor().clamp(0, height - 2)
+    s, t = fu - i, fv - j
+    i = i.long().expand(-1, 13)
+    j = j.long().expand(17, -1)
+    lower = ((s + t) <= 1.0).unsqueeze(-1)
+    corner_0 = torch.where(lower, grid[i, j], grid[i + 1, j])
+    corner_1 = grid[i, j + 1]
+    corner_2 = torch.where(lower, grid[i + 1, j], grid[i + 1, j + 1])
+    weight_1 = torch.where(lower[..., 0], t, 1 - s).unsqueeze(-1)
+    weight_2 = torch.where(lower[..., 0], s, s + t - 1).unsqueeze(-1)
+    flat = (
+        (1 - weight_1 - weight_2) * corner_0 + weight_1 * corner_1 + weight_2 * corner_2
+    )
+
+    assert torch.allclose(locations, flat, atol=1e-5)
+
+
+def test_resolution_defaults_to_the_texture_then_to_the_grid():
+    SceneManager.reset()
+    plain = Surface(grid_width=6, grid_height=4)
+    assert plain.get_texture_locations().shape == (6, 4, 3), (
+        "with no texture to match, the grid resolution is the sensible default"
+    )
+
+    textured = Surface(
+        grid_width=6, grid_height=4, color_texture=torch.zeros(12, 20, 5)
+    )
+    assert textured.get_texture_locations().shape == (12, 20, 3), (
+        "a surface that has a texture should default to that texture's shape"
+    )
+    assert textured.get_texture_locations(9).shape == (9, 9, 3)
+
+
+def test_chunking_is_invisible():
+    """Large maps are resolved a block of texels at a time; the blocking must
+    not be able to change an answer.
+    """
+    SceneManager.reset()
+    torus = Torus()
+    whole = torus.get_texture_locations((40, 24))
+
+    original = surface_module._TEXTURE_LOCATION_CHUNK_TEXELS
+    try:
+        surface_module._TEXTURE_LOCATION_CHUNK_TEXELS = 25
+        chunked = torus.get_texture_locations((40, 24))
+    finally:
+        surface_module._TEXTURE_LOCATION_CHUNK_TEXELS = original
+
+    assert torch.equal(whole, chunked)
+
+
+def test_a_packed_surface_says_why_it_cannot_answer():
+    SceneManager.reset()
+    pack = Sphere.from_batches(torch.tensor([[0.0, 0.0, 0.0], [3.0, 0.0, 0.0]]))
+
+    with pytest.raises(ValueError, match="packed surface"):
+        pack.get_texture_locations((8, 8))
+
+
+def test_a_degenerate_grid_and_an_empty_resolution_are_rejected():
+    SceneManager.reset()
+    sliver = Surface(grid_width=1, grid_height=6)
+    with pytest.raises(ValueError, match="at least 2 grid points"):
+        sliver.get_texture_locations((8, 8))
+
+    plane = Surface(grid_width=4, grid_height=4)
+    with pytest.raises(ValueError, match="positive on both axes"):
+        plane.get_texture_locations((8, 0))


### PR DESCRIPTION
## What and why

A texture is addressed in `(u, v)`, which is the wrong language for a map whose content depends on *where the surface is* — "colour everything above the equator", "redder the further from the origin". There was no way to write one: you can reach the vertex positions through `surface.grid.location`, but a texture has its own resolution, so the vertex grid is the wrong shape to build a map from.

`Surface.get_texture_locations(resolution=None)` closes that: it returns the world position of every texel, laid out exactly like a texture map, so the map can be written as arithmetic on 3-D coordinates.

```python
globe = Sphere(radius=1.5)
height = globe.get_texture_locations((128, 128))[..., 1:2]
globe.color_texture = BLUE.mult_opacity((height > 0).float())
```

The positions come from the surface's **mesh**, not from `coord_function`, and that is the design decision worth reviewing. Two reasons:

- **There is no staleness question to answer.** A grid that was deformed, morphed with `set_shape_to`, or assigned to directly is still the grid that gets drawn. Reading it means no branch, and no freshness test that could be wrong — and there is no cheap honest test available anyway: the only comparison on offer is `_current_surface_function`'s affine fit, which costs more than the answer does and is valid only while the Mob's transform is unchanged.
- **It is the more accurate answer even when the coordinate function is current.** The kernel interpolates the triangle corners' UVs barycentrically, and the geometry beneath them is the logical PN patch, so a texel lands on that patch at the barycentric coordinate its UV resolves to — not on the analytic surface at the same parameter. On a stock `Sphere` the two differ tangentially by ~12% of a grid cell (0.025 world units, measured): sub-texel on a 64-wide map, a 7-texel scalloped boundary on a 1024-wide one.

Two conventions are folded in because a caller cannot reasonably reproduce them: the wrap padding, which puts texel `i` at `i / W` rather than `i / (W - 1)` on an axis that closes, and the PN curvature between grid vertices, which plain bilinear interpolation of the vertex grid misses by 2.5% of a sphere's radius. `ignore_normals` needs no special case — the renderer has no vertex normals there, and zero normals collapse a PN patch onto its flat triangle, which is what gets drawn.

A packed surface from `from_batches` raises rather than guessing: its members share one texture, so a texel has one position per member.

### One fix that came with it

`WHITE.mult_opacity(surface.grid.location[..., 1:2])` — the idiom this feature was meant to mirror — did not work. Not for texels and not for vertices either: a named colour is a single `[5]` row, so `prep_set` had nothing to broadcast the value into, and both spellings raised out of `expand()`. (`surface.grid.color.mult_opacity(...)` worked, because that colour already carries axes.)

`Color.prep_set` now gives the colour the leading axes of the value being painted onto it, so both spellings work. It only triggers when the value really carries a grid: a scalar opacity arrives padded to `[1, 1, 1]`, and inflating `WHITE.set_opacity(0.5)` from `[5]` to `[1, 1, 5]` would change the shape every existing caller gets back. Each previously-working shape was checked against the old behaviour and is unchanged.

Happy to split this out if you would rather keep it separate — it is here because without it the feature cannot be used in the form it was asked for.

## Rendered output

**Unchanged.** `tests/fast` and all six `tests/full_renders` scenes pass pixel-wise against the committed `expected_outputs_cpu/` baselines on this machine. No baseline was regenerated.

That is the expected result rather than a lucky one: `get_texture_locations` and the new `evaluate_logical_pn_per_patch` are additive and nothing in the render path calls them. The only change reaching rendering is `Color.prep_set`, and its two render-path callers (the colour-texture opacity multiply in `Surface._build_render_primitive`, and the equivalent in `TriangleMesh`) both pass a value whose dimensions already match the colour's, where the new step is a no-op view. Every other caller in the package passes a scalar and skips it entirely.

## Verification

Run on a CPU-only cloud session (no GPU):

- `pytest -q --fast` — 211 passed
- `pytest -q tests/unit_tests tests/fast` — 1147 passed, 92 skipped (CI's paths)
- `pytest -q tests/full_renders` — 7 passed
- `ruff check --no-fix` — clean
- `python docs/make_and_open_docs.py --skip-examples --no-open` — builds clean; the one warning is a pre-existing missing graphviz `dot`

**Not checked here: CUDA.** This machine has no GPU, so `expected_outputs_cuda/` is untested and CPU/CUDA divergence is unverified. Nothing in the diff is device-specific — it is torch tensor arithmetic on the animation device, no kernel changes — but that is an argument, not a measurement.

22 new tests, unmarked (they only fail when their own area changes). The load-bearing ones:

- every texel of a sphere sits within `geometry_tolerance` of its true surface;
- the closed-form cell lookup agrees with a brute-force search over the renderer's own triangle list, built the way `_build_render_primitive` builds it — max difference 3.6e-7;
- a closed axis leaves room for the wrap, where clamping would collapse the closing step to zero;
- positions track a grid written by hand while `coord_function` still describes the old shape;
- `ignore_normals` reports the flat triangles that are drawn;
- chunking a large map is byte-identical to resolving it whole.

## Docs

Public API, so `DOCSTRINGS.md` applies: `get_texture_locations` carries a full NumPy-style docstring — types in annotations only, the default of `resolution` stated in prose, an `Animation` section saying it is a query that records nothing, `Raises` for all three rejections, and an `.. algan::` example calling `Scene.save_video()` once. `evaluate_logical_pn_per_patch` is internal and documents how it differs from `evaluate_logical_pn`.

`docs/source/advanced_user_tutorials/images_and_textures.rst` gains a "Building a map from world positions" section under *Texturing Any Surface*, with a rendered example and the caveat that a texture is carried in `(u, v)`, so colours derived from world position travel with the surface when it later moves — recompute them in an updater to lock them to world space. The reference page picks the method up through autosummary; there are no checked-in stubs to update.