### PR TITLE
Dice logical PN patches once per patch, not once per frame

### DIFF
--- a/DESIGN_optimization_targets.md
+++ b/DESIGN_optimization_targets.md
@@ -23,7 +23,7 @@ reference workload: `s05_learning_to_program_setup.py` at `LD` (864x486, 15 fps,
 | --- | --- |
 | **T1** PN subdivision-level criterion | **shipped and confirmed end to end** -- 67.9 s -> 1.40 s |
 | **T2** Bezier chord-count search | **shipped and confirmed end to end** -- 18.4 s -> 0.89 s |
-| **T4** dice write-out (cheap half only) | **shipped** -- byte-exact, but only ~1.07x |
+| **T4** dice write-out | **shipped, and re-scoped by what it found** -- the dice ignored *temporal coherence*: a mesh that holds still is handed T identical source rows and diced T times. Collapsing them, deduping the patch evaluation and interpolating attributes on the shared vertices is **1.19-1.39x on the whole dice** (and 1.03x on a genuinely deforming mesh, which has nothing to share), so more than that on the write-out, which is 15-35% of the dice here. **Bit-identical**, and all six full-render scenes match their CPU baselines. The `allocate()` zero-fills the last revision nominated turn out to be **4%** of the write-out, not its expensive half. See T4 |
 | **P2** contiguous replay time-selector | **shipped** -- 1.62x on replay-time `get`/`modify` |
 | **P3** lazily-zeroed remat buffer | **shipped** -- 1.20x on `rematerialize_state_at_times` |
 | **P4** whole-scene per-batch scans | **shipped** -- honestly ~3.7 s of a ~500 s render (66x on the actor filter), not the 11.63 s first reported; see the correction under P4 |
@@ -224,8 +224,10 @@ already been wrapping correctly all along (it just predated the helper), and
 * A/B parity scripts for the shipped work, the kernel ones CUDA-only:
   `benchmarks/_pn_criterion_kernel_ab.py` (levels + shared-edge agreement +
   timing, static *and* moving meshes), `benchmarks/_bez_chord_kernel_ab.py`
-  (chord counts + timing), `benchmarks/_pn_dice_scatter_ab.py` (byte-equality of
-  every diced array), `benchmarks/_logical_pn_crack_check.py` (seam integrity),
+  (chord counts + timing), `benchmarks/_pn_dice_ab.py` (the dice against its
+  pre-temporal-coherence self: bit-equality of every diced array, plus
+  alternating in-process timing, on static / orbiting / deforming meshes),
+  `benchmarks/_logical_pn_crack_check.py` (seam integrity),
   `benchmarks/_p1_zerofill_ab.py` (the lazily-zeroed buffer, CPU),
   `benchmarks/_query_rowdedup_parity.py` (the endpoint row dedup, CPU: dense
   path == dedup path == brute force, with every branch -- fast path, break-even
@@ -567,19 +569,104 @@ large as the input and the bandwidth argument is weaker. Worth a
 `memory.scope`-level breakdown before committing. **Estimated** 47.1 s -> ~25 s
 (~2.7%), lower confidence.
 
-### T4. The dice write-out -- ~17 s (2.1%) -- **cheap half done, disappointing**
+### T4. The dice write-out -- **temporal coherence, shipped**
 
-> `_scatter_diced_rows` now folds (frame, column) into one flattened row index
-> and writes each output with a single `index_copy_` over `[T * M, ...]`
-> (`padding` with `index_fill_`). **Byte-identical** -- every diced array
-> compares equal on `benchmarks/_pn_dice_scatter_ab.py`.
+> The item was framed as "the write-out moves too many bytes", and both halves
+> of that framing were wrong. The dice's real problem was that **it recomputed
+> the same answer once per frame**: a patch's diced geometry is a function of
+> the patch and its level and *nothing else* -- the camera only picks the level
+> -- while materialization hands the dice one source row per frame whether or
+> not the mob moved. A still `Sphere` reaches it as T byte-identical copies
+> (measured on a two-mob scene: `corners` arrives `[4, 508, 3, 3]` with
+> `distinct_frames = 1`) and was diced T times over.
 >
-> But it is only **1.02-1.19x on the whole dice** (257 ms -> 239 ms across four
-> meshes), not the ~2x on the write-out the estimate below assumed. `index_put_`
-> was apparently not costing much more than `index_copy_` here. Kept -- it is
-> free and byte-exact -- but the remaining T4 estimate should be treated as
-> unproven, and the `allocate()` zero-fills (not the scatter) are the likelier
-> half of that 17 s.
+> Shipped, all **bit-identical** (`benchmarks/_pn_dice_ab.py` runs the
+> pre-change dice beside the current one in one process and compares every
+> diced array bit for bit -- corners, normals, colours, the surface and shader
+> parameters, uvs, the padding mask, both level arrays and the per-row surface
+> ids -- across static, orbiting, multi-level and deforming meshes):
+>
+> 1. **`_collapse_redundant_frames`.** Detect the identical rows (compare frame
+>    1 first, so a genuinely deforming mesh is rejected for a (T-1)th of the
+>    cost) and keep one. The three control-net builds --
+>    `logical_pn_control_points`, `logical_pn_normal_control_points`,
+>    `logical_pn_edge_control_points`, together ~25% of the write-out -- then
+>    run once instead of T times, and `_frame_broadcast_base` hands the
+>    criterion kernels a stride-0 net instead of T uploaded copies of one
+>    answer.
+> 2. **Per-patch dedup in the write-out.** The selected pairs are listed
+>    PATCH-major (`nonzero` on the transpose), so a patch's frames share a
+>    chunk; the patch and normal evaluations then run once per distinct patch
+>    and fan out with one `index_select`. Measured **9-20x** fewer evaluations
+>    than pairs under a fast orbit, and exactly T when the camera holds still.
+>    The boundary snap stays per row -- two frames dicing one patch need not
+>    agree on its boundary levels.
+> 3. **Attributes interpolate on the shared subdivision vertices**
+>    (`interpolate_patch_vertex_attribute`) and gather through
+>    `subdivision_triangle_indices` instead of being evaluated at every
+>    microtriangle corner: the corners *are* those vertices, so it is the same
+>    arithmetic over a sixth as many of them.
+>
+> The same dedup is applied to the **torch fallback** of the patch-flatness
+> criterion (`share_patches`), which re-evaluated a patch once per frame still
+> searching. Deliberately off on the kernel path, which keeps its samples in
+> registers and has nothing to share.
+>
+> **1.19-1.39x on the whole dice** across the six meshes that hold still while
+> the camera moves, and **1.03x** on the deforming one, which has nothing to
+> share and only pays the (short-circuited) invariance test. The dice on this
+> CPU-only machine is 65-85% level search, so the share that actually moved
+> improved by considerably more than the headline.
+>
+> Verified end to end: all six `tests/full_renders` scenes match their
+> committed **CPU** baselines here. That is a real check on this machine and not
+> a vacuous one -- re-baselining on it before the change rewrote every file
+> byte-identically, so the committed CPU set *is* this machine's output. CUDA is
+> unverified: this session has no GPU, and the criterion-kernel path
+> (`share_patches` off, stride-0 control nets) is only exercised there.
+
+#### Three things measured here that change what to do next
+
+* **The `allocate()` zero-fills are not the expensive half.** The previous
+  revision nominated them as where a fresh attempt should start. Measured:
+  `torch.zeros` is **4%** of the write-out on CPU (9.3 ms of 227 ms on a
+  32-frame, 1056-patch batch) and proportionally less on a device that memsets
+  at hundreds of GB/s. Filling only the padding *is* available -- the unwritten
+  rows are each frame's contiguous tail -- it is simply not worth the branch.
+  Do not spend the round there.
+* **Deduping the attribute interpolation is a net loss.** A barycentric blend
+  of three corner values is cheap enough that fanning the result back out costs
+  more than recomputing it per row: **0.86x** on a deforming mesh whose colours
+  were frame invariant. Only the patch evaluation -- a ten-term polynomial plus
+  a snap, twenty-odd passes -- is expensive enough for the trade to pay. That
+  asymmetry is the rule to carry: dedup buys nothing unless what it skips costs
+  more than a gather.
+* **Emitting a `[1, ...]` diced array is worth much less than it looks.** When
+  the levels *and* the edge levels come out frame-uniform (a still mesh, which
+  is common) the whole diced output is T identical copies, and the flat path
+  already accepts `[1, N]` geometry. But `scene_builder`'s
+  `_cat_collections` runs `_unify_time` over the primitives it concatenates, so
+  a single moving flat mesh anywhere in the scene expands the static one
+  straight back out at merge time. The saving is confined to the primitive's
+  own allocation and packing -- real, but not the T-fold win the shape
+  suggests, and it changes the primitive's output contract (three tests assert
+  a per-frame diced array). Left undone deliberately.
+
+#### Where the dice's remaining cost is
+
+On CPU it is **the level search, not the write-out**: 65-85% of
+`_dice_logical_pn` across the benchmark's meshes. The criterion is inherently
+expensive -- per level tried it evaluates each patch at `V + 13 * 4 ** L`
+parameters and perspective-projects *both* the exact and the approximated point
+sets, so it does ~26 projections per output triangle where the dice does ~1.5
+vertex evaluations. On CUDA that is T1's fused kernel and costs nothing. **The
+obvious next move for the CPU path is to let those same kernels run on Taichi's
+x64 backend** -- `pn_criterion_kernel_active` gates them on a CUDA *render
+device* today, and the "Taichi would stage every argument through VRAM"
+objection in that comment is about CUDA-arch Taichi against CPU torch tensors,
+not about a CPU-arch runtime. It is not free: `fast_math` flips borderline
+levels, so it would move the CPU baselines exactly as T1 moved the CUDA ones,
+and it needs the same deliberate re-baseline.
 
 #### Why it was a target (original measurement)
 
@@ -587,16 +674,11 @@ large as the input and the bandwidth argument is weaker. Worth a
 (3.1 s), `evaluate_logical_pn_normals` (1.0 s) and `snap_boundary_values`
 (0.4 s). Two costs were identified: the `allocate()` zero-fills
 (`[T, max_triangles, 3, D]` for corners, normals, colours and every
-surface/shader parameter) and the advanced-index scatters.
-
-**The scatter half is done and was worth little (above), so the remaining
-`~17 s -> ~8 s` estimate now rests entirely on the untested half: the
-`allocate()` zero-fills.** That is where a fresh attempt should start --
-`max_triangles` is the batch's *widest frame*, so every frame's buffer is padded
-to it and the surplus is zeroed for nothing. Sizing per frame, or filling only
-the padding rows, is the idea to test. Writing the dice as a kernel (the more
-expensive option originally sketched here) should wait until the zero-fill has
-been measured on its own.
+surface/shader parameter) and the advanced-index scatters. An earlier round
+folded (frame, column) into one flattened row index so each output is written
+with a single `index_copy_` over `[T * M, ...]`; that was byte-exact and worth
+**1.02-1.19x** on the whole dice, well under the ~2x it assumed. Neither
+identified cost was the real one.
 
 ### T5. Sparse-coverage host chain -- ~37.7 s of 95.5 s (~9.9%) -- **next**
 
@@ -1638,9 +1720,12 @@ every round has left alone.
    has risen across three re-profiles purely because prep keeps shrinking, so
    the two poles are nearly level again and the "prefer prep at equal size"
    advice is close to expiring.
-6. **T3** (5.6%), then **T4's remaining half** (the `allocate()` zero-fills --
-   small, its estimate unproven, and P3 suggests the same lazily-zeroed trick
-   may apply; fold it in whenever the dice is open anyway), then **T6** (1.7%).
+6. **T3** (5.6%), then **T6** (1.7%). **T4 is done** -- and its `allocate()`
+   zero-fills, which this list used to nominate, were measured at 4% of the
+   write-out and are not worth opening the dice for. What T4 left behind is a
+   *CPU-path* item, not a reference-scene one: the level search is 65-85% of
+   the dice without the criterion kernels, which are gated on a CUDA render
+   device. See T4.
 
 Ruled out this round: further search-count work in `_query_row_states` (P6:
 write-bound now), bloom as a Taichi kernel (measured far slower), and the

--- a/DESIGN_optimization_targets.md
+++ b/DESIGN_optimization_targets.md
@@ -23,7 +23,7 @@ reference workload: `s05_learning_to_program_setup.py` at `LD` (864x486, 15 fps,
 | --- | --- |
 | **T1** PN subdivision-level criterion | **shipped and confirmed end to end** -- 67.9 s -> 1.40 s |
 | **T2** Bezier chord-count search | **shipped and confirmed end to end** -- 18.4 s -> 0.89 s |
-| **T4** dice write-out | **shipped, and re-scoped by what it found** -- the dice ignored *temporal coherence*: a mesh that holds still is handed T identical source rows and diced T times. Collapsing them, deduping the patch evaluation and interpolating attributes on the shared vertices is **1.19-1.39x on the whole dice** (and 1.03x on a genuinely deforming mesh, which has nothing to share), so more than that on the write-out, which is 15-35% of the dice here. **Bit-identical**, and all six full-render scenes match their CPU baselines. The `allocate()` zero-fills the last revision nominated turn out to be **4%** of the write-out, not its expensive half. See T4 |
+| **T4** dice write-out | **shipped, and re-scoped by what it found** -- the dice ignored *temporal coherence*: a mesh that holds still is handed T identical source rows and diced T times. Collapsing them, deduping the patch evaluation and interpolating attributes on the shared vertices is **1.27-1.37x on the dice calls that can use it and 1.05-1.15x on the dice overall, measured inside real renders** -- because only 19-55% of a real scene's dice time has frame-invariant geometry. **Bit-identical**, and all six full-render scenes match their CPU baselines. Read the "how much of a real scene is static" measurement before extrapolating from a synthetic mesh. The `allocate()` zero-fills the last revision nominated turn out to be **4%** of the write-out, not its expensive half. See T4 |
 | **P2** contiguous replay time-selector | **shipped** -- 1.62x on replay-time `get`/`modify` |
 | **P3** lazily-zeroed remat buffer | **shipped** -- 1.20x on `rematerialize_state_at_times` |
 | **P4** whole-scene per-batch scans | **shipped** -- honestly ~3.7 s of a ~500 s render (66x on the actor filter), not the 11.63 s first reported; see the correction under P4 |
@@ -612,18 +612,47 @@ large as the input and the bandwidth argument is weaker. Worth a
 > searching. Deliberately off on the kernel path, which keeps its samples in
 > registers and has nothing to share.
 >
-> **1.19-1.39x on the whole dice** across the six meshes that hold still while
-> the camera moves, and **1.03x** on the deforming one, which has nothing to
-> share and only pays the (short-circuited) invariance test. The dice on this
-> CPU-only machine is 65-85% level search, so the share that actually moved
-> improved by considerably more than the headline.
->
 > Verified end to end: all six `tests/full_renders` scenes match their
 > committed **CPU** baselines here. That is a real check on this machine and not
 > a vacuous one -- re-baselining on it before the change rewrote every file
 > byte-identically, so the committed CPU set *is* this machine's output. CUDA is
 > unverified: this session has no GPU, and the criterion-kernel path
 > (`share_patches` off, stride-0 control nets) is only exercised there.
+
+#### How much it is worth, and why the synthetic number overstated it
+
+On isolated meshes `benchmarks/_pn_dice_ab.py` reports **1.13-1.33x** for a mesh
+that holds still while the camera moves. **Do not quote that as the render-level
+figure.** Measured *inside* a real render, by running both dice implementations
+on every call with the same inputs and alternating which goes first:
+
+| scene | dice calls | frame-invariant | deforming | whole dice |
+| --- | --- | --- | --- | --- |
+| `solids_and_camera` | 10 | **1.37x** (2 calls, 22% of dice time) | 0.98x | **1.05x** |
+| `materials_and_lighting` | 38 | **1.27x** (20 calls, 60%) | 1.01x | **1.15x** |
+| `complex_hierarchy_become` | 4 | -- (one 10 ms call) | 1.14x | **1.14x** |
+
+The gap is not a measurement artifact, it is the workload: **a mob's `corners`
+are world-space**, so "frame invariant" means the mob does not move *at all*
+during the batch, and a scene whose whole point is motion spends most of its
+dice time on meshes that do move. `solids_and_camera` has 2 of 10 calls static;
+`materials_and_lighting`, which animates the camera around mostly-parked
+spheres, has 20 of 38. Batches are large (101 and 138 frames here), so where it
+does fire the redundancy removed is correspondingly large.
+
+`_dice_logical_pn` was ~18% of `solids_and_camera`'s render, so 1.05x on the
+dice is ~1% of that render. On `materials_and_lighting` the dice is a bigger
+share and the saving is 2.9 s of 22.5 s.
+
+**And one thing this measurement caught that the synthetic benchmark hid.**
+Listing the work list patch-major is what lets the dedup see its duplicates,
+but it is not free: consecutive rows then write a whole frame apart in the
+output instead of in one run, and read their control points the same way. On
+the deforming half of `materials_and_lighting`'s calls -- which have nothing to
+dedup -- that cost **0.965x** while the isolated benchmark's deforming mesh
+reported a harmless 1.03x. Patch-major ordering is therefore gated on
+`geometry_static`, exactly as `share_patches` is in the search; with the gate
+the same calls measure 1.005x. A synthetic mesh was too small to show it.
 
 #### Three things measured here that change what to do next
 

--- a/algan/rendering/logical_pn.py
+++ b/algan/rendering/logical_pn.py
@@ -542,9 +542,31 @@ def interpolate_patch_attribute(values, triangle_uv):
     Attributes are linear in the barycentric coordinates, so this needs no
     boundary snapping: along a shared edge the interpolant depends only on the
     two endpoint values, which both patches hold in common.
+
+    The dice itself calls :func:`interpolate_patch_vertex_attribute`, which
+    evaluates a sixth as many points and gathers.  This is kept as the
+    definition that one is stated against: the equivalence test and the dice's
+    A/B reference arm (``benchmarks/_pn_dice_ab.py``) both compare to it, so it
+    is not dead code.
     """
     weights = triangle_uv_to_barycentric(triangle_uv)
     return torch.einsum("mak,pkc->pmac", weights, values)
+
+
+def interpolate_patch_vertex_attribute(values, vertex_uv):
+    """Interpolate per-corner patch attributes onto the *shared* dice vertices.
+
+    ``values`` is ``[K, 3, C]`` and ``vertex_uv`` is ``[V, 2]``; the result is
+    ``[K, V, C]``.  Gathering that through :func:`subdivision_triangle_indices`
+    reproduces :func:`interpolate_patch_attribute` exactly -- a microtriangle's
+    corners *are* these vertices, and :func:`subdivision_triangle_uvs` is
+    literally this vertex list gathered through those indices -- for a sixth of
+    the arithmetic, because a vertex is a corner of up to six microtriangles.
+    It is the attribute counterpart of what
+    :func:`subdivision_vertex_uvs` already does for positions.
+    """
+    weights = triangle_uv_to_barycentric(vertex_uv)
+    return torch.einsum("vk,pkc->pvc", weights, values)
 
 
 __all__ = [
@@ -554,6 +576,7 @@ __all__ = [
     "evaluate_logical_pn",
     "evaluate_logical_pn_normals",
     "interpolate_patch_attribute",
+    "interpolate_patch_vertex_attribute",
     "logical_pn_control_points",
     "logical_pn_edge_control_points",
     "logical_pn_normal_control_points",

--- a/algan/rendering/raytracing/primitives.py
+++ b/algan/rendering/raytracing/primitives.py
@@ -91,9 +91,7 @@ class _PatchChunk(NamedTuple):
     def of(cls, patches, frames, dedup):
         if not dedup:
             return cls(patches, frames, None, None)
-        unique_patches, inverse = torch.unique_consecutive(
-            patches, return_inverse=True
-        )
+        unique_patches, inverse = torch.unique_consecutive(patches, return_inverse=True)
         return cls(patches, frames, unique_patches, inverse)
 
     def rows_of(self, source, static):
@@ -1712,9 +1710,9 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
         # when it is past that frame's diced total. Stating it that way costs
         # one comparison over the grid, where marking the written rows costs a
         # fill plus an index_fill_ per chunk.
-        padding = torch.arange(max_triangles, device=device).unsqueeze(
-            0
-        ) >= counts.sum(1).unsqueeze(1)
+        frame_totals = counts.sum(1)
+        batch_columns = torch.arange(max_triangles, device=device)
+        padding = batch_columns >= frame_totals.unsqueeze(1)
 
         for level in levels.unique(sorted=True).tolist():
             level = int(level)
@@ -1815,9 +1813,7 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
                 for output, source in attribute_outputs:
                     _scatter_diced_rows(
                         output,
-                        chunk_rows.diced_attribute(
-                            source, vertex_uv, triangle_indices
-                        ),
+                        chunk_rows.diced_attribute(source, vertex_uv, triangle_indices),
                         targets,
                     )
 

--- a/algan/rendering/raytracing/primitives.py
+++ b/algan/rendering/raytracing/primitives.py
@@ -1718,14 +1718,24 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
 
         for level in levels.unique(sorted=True).tolist():
             level = int(level)
-            # PATCH-major, not frame-major: ``nonzero`` on the transpose lists
-            # every frame of a patch consecutively, which is what lets the
-            # per-patch dedup below see its duplicates inside one chunk (a
+            # PATCH-major *only where the dedup can use it*: ``nonzero`` on the
+            # transpose lists every frame of a patch consecutively, which is
+            # what lets the dedup below see its duplicates inside one chunk (a
             # frame-major list puts a patch's frames a whole frame apart, so on
-            # any mesh wider than a chunk no two would ever share one). The
-            # writes are disjoint and ``index_copy_`` does not care about
-            # order, so the diced output is unchanged.
-            selected = (levels == level).t().contiguous().nonzero()
+            # any mesh wider than a chunk no two would ever share one). It is
+            # not free -- consecutive rows then write a frame apart in the
+            # output instead of in one run, and read their control points the
+            # same way -- so a deforming mesh, which has nothing to dedup,
+            # stays frame-major and keeps its contiguous writes. Measured: 1.03x
+            # against 0.97x on the deforming half of a real scene's dice calls.
+            # The writes are disjoint and ``index_copy_`` does not care about
+            # order, so the diced output is the same either way.
+            trying = levels == level
+            selected = (
+                trying.t().contiguous().nonzero().flip(-1)
+                if geometry_static
+                else trying.nonzero()
+            )
             vertex_uv = subdivision_vertex_uvs(level, device=device, dtype=dtype)
             triangle_indices = subdivision_triangle_indices(level, device=device)
             boundary = subdivision_boundary_map(level, device=device)
@@ -1735,7 +1745,7 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
 
             for start in range(0, selected.shape[0], chunk):
                 rows = selected[start : start + chunk]
-                patches, frames = rows[:, 0], rows[:, 1]
+                frames, patches = rows[:, 0], rows[:, 1]
                 edges = edge_levels[frames, patches]
 
                 # A patch's diced geometry depends on the patch and its level,

--- a/algan/rendering/raytracing/primitives.py
+++ b/algan/rendering/raytracing/primitives.py
@@ -12,7 +12,7 @@ from algan.rendering.logical_pn import (
     evaluate_cubic_curve,
     evaluate_logical_pn,
     evaluate_logical_pn_normals,
-    interpolate_patch_attribute,
+    interpolate_patch_vertex_attribute,
     logical_pn_control_points,
     logical_pn_edge_control_points,
     logical_pn_normal_control_points,
@@ -69,6 +69,61 @@ def _sample_tensor(values, device, dtype):
         cached = torch.tensor(values, device=device, dtype=dtype)
         _SAMPLE_TENSOR_CACHE[key] = cached
     return cached
+
+
+class _PatchChunk(NamedTuple):
+    """One chunk of the dice's ``(frame, patch)`` work list, deduped by patch.
+
+    The dice walks its selected pairs in PATCH-major order, so the frames that
+    dice a given patch at a given level are consecutive.  ``unique_patches``
+    then names each distinct patch once and ``inverse`` maps every row of the
+    chunk back to its entry, which is all a frame-invariant source needs to be
+    evaluated once and fanned out.  Both are ``None`` when nothing in this dice
+    is frame invariant, and every method falls back to the per-row path.
+    """
+
+    patches: torch.Tensor  # [K] long
+    frames: torch.Tensor  # [K] long
+    unique_patches: torch.Tensor | None  # [U] long, ascending
+    inverse: torch.Tensor | None  # [K] long into unique_patches
+
+    @classmethod
+    def of(cls, patches, frames, dedup):
+        if not dedup:
+            return cls(patches, frames, None, None)
+        unique_patches, inverse = torch.unique_consecutive(
+            patches, return_inverse=True
+        )
+        return cls(patches, frames, unique_patches, inverse)
+
+    def rows_of(self, source, static):
+        """This chunk's rows of ``source``, and whether they were deduped."""
+        if static and self.unique_patches is not None:
+            return source[0].index_select(0, self.unique_patches), True
+        return source[self.frames, self.patches], False
+
+    def fan_out(self, values, deduped):
+        """Expand per-distinct-patch ``values`` back to one row per pair."""
+        return values.index_select(0, self.inverse) if deduped else values
+
+    def diced_attribute(self, source, vertex_uv, triangle_indices):
+        """Interpolate a per-corner attribute onto this chunk's triangle soup.
+
+        Interpolating on the shared subdivision vertices and gathering through
+        ``triangle_indices`` is the same arithmetic on the same values as
+        interpolating at every microtriangle corner -- the corners *are* those
+        vertices -- over a sixth as many of them.
+
+        Deliberately NOT deduped, even where the attribute is frame invariant
+        and the rows are there for the taking: a barycentric blend of three
+        corner values is so cheap that fanning the result back out costs more
+        than evaluating it per row (measured 0.86x on a deforming mesh whose
+        colours were static). Only the patch evaluation is expensive enough for
+        the trade to pay.
+        """
+        values = source[self.frames, self.patches]
+        values = interpolate_patch_vertex_attribute(values, vertex_uv)
+        return values[:, triangle_indices]
 
 
 class _PNCriterionInputs(NamedTuple):
@@ -1053,7 +1108,14 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
         return torch.bitwise_left_shift(torch.ones_like(levels), 2 * levels)
 
     def _required_subdivision_levels(
-        self, control_points, edge_controls, cam_o, sp, sb, screen_height
+        self,
+        control_points,
+        edge_controls,
+        cam_o,
+        sp,
+        sb,
+        screen_height,
+        geometry_static=False,
     ):
         """Choose the crack-free logical PN levels of every patch and edge.
 
@@ -1078,6 +1140,11 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
             front_sign,
             screen_height,
             kernel,
+            # The torch fallback re-evaluates a patch once per frame that is
+            # still searching; the kernel keeps its samples in registers and
+            # has nothing to share, so only the fallback wants the work list
+            # grouped for dedup.
+            geometry_static and kernel is None,
         )
         if edge_capped or patch_capped:
             warnings.warn(
@@ -1238,7 +1305,14 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
         return error
 
     def _required_patch_levels(
-        self, control_points, start, cam, front_sign, screen_height, kernel=None
+        self,
+        control_points,
+        start,
+        cam,
+        front_sign,
+        screen_height,
+        kernel=None,
+        share_patches=False,
     ):
         """Per-patch interior subdivision levels, shape ``[T, P]``.
 
@@ -1271,7 +1345,16 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
         capped = torch.zeros((), dtype=torch.bool, device=levels.device)
 
         for level in range(int(levels.amin().item()), max_level + 1):
-            selected = (unresolved & (levels == level)).nonzero()
+            trying = unresolved & (levels == level)
+            # PATCH-major when the criterion can share a patch's evaluation
+            # between the frames still trying it (see ``_patch_flatness_error``);
+            # the rows are independent, so this only decides who lands in a
+            # chunk together.
+            selected = (
+                trying.t().contiguous().nonzero().flip(-1)
+                if share_patches
+                else trying.nonzero()
+            )
             if not selected.shape[0]:
                 if not bool(unresolved.any()):
                     break
@@ -1285,6 +1368,7 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
                 front_sign,
                 screen_height,
                 kernel,
+                share_patches,
             )
             failed = (error * self._flatness_safety_factor) > threshold
             if level == max_level:
@@ -1319,6 +1403,7 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
         front_sign,
         screen_height,
         kernel=None,
+        share_patches=False,
     ):
         """Peak pixel deviation of each selected patch's level-``level`` dice,
         sampled at ``_flatness_sample_weights`` within every microtriangle.
@@ -1375,8 +1460,15 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
         for start in range(0, selected.shape[0], chunk):
             rows = selected[start : start + chunk]
             frames, patches = rows[:, 0], rows[:, 1]
-            controls = control_points[frames, patches].unsqueeze(0)
-            evaluated = evaluate_logical_pn(controls, combined_uv)[0]
+            # What the criterion asks of the patch -- where its surface and its
+            # level-``level`` dice sit in space -- has nothing to do with the
+            # camera; only the projection that follows does. So a patch several
+            # frames are still trying at this level is evaluated once and its
+            # points fanned out, which is why ``_required_patch_levels`` hands
+            # the rows over patch-major (see ``share_patches``).
+            shared = _PatchChunk.of(patches, frames, share_patches)
+            controls, deduped = shared.rows_of(control_points, share_patches)
+            evaluated = evaluate_logical_pn(controls.unsqueeze(0), combined_uv)[0]
             vertices = evaluated[:, :num_vertices]
             # The sample points stay in their flat (microtriangle, sample)
             # order and the approximation is flattened to match, rather than
@@ -1387,8 +1479,8 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
                 "sk,pmkc->pmsc", weights, vertices[:, triangle_indices]
             )
             error[start : start + chunk] = self._guarded_pixel_error(
-                evaluated[:, num_vertices:],
-                approximated.flatten(1, 2),
+                shared.fan_out(evaluated[:, num_vertices:], deduped),
+                shared.fan_out(approximated.flatten(1, 2), deduped),
                 tuple(value.index_select(0, frames) for value in cam),
                 front_sign.index_select(0, frames),
                 screen_height,
@@ -1405,10 +1497,57 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
             )
         return _expand_frames(value, num_frames)
 
+    @staticmethod
+    def _collapse_redundant_frames(value):
+        """Drop a source array's frame axis when every frame holds the same
+        values, returning ``(array, frame_invariant)``.
+
+        Materialization hands a mob's attributes back one row per frame even
+        when the mob does not move, so a *static* mesh arrives here as ``T``
+        byte-identical copies of one geometry.  Nothing downstream of this
+        method needs the copies: the control nets are a function of the source
+        alone, so building them ``T`` times produces ``T`` identical answers,
+        the criterion kernels then upload ``T`` copies of a net they index by
+        one frame, and the dice evaluates each patch once per frame to the same
+        point.  Collapsing here is what lets all three notice.
+
+        The test is an equality reduction over the source (cheap next to the
+        dice, which is quadratically larger), and it is deliberately
+        conservative: NaN never compares equal, so a mesh carrying one falls
+        back to the per-frame path rather than being silently unified.
+        """
+        if value is None:
+            return None, False
+        if value.shape[0] == 1 or value.stride(0) == 0:
+            return value[:1], True
+        # Frame 1 first: a mesh that really is deforming differs there, and
+        # that one comparison rejects it for a (T-1)th of what comparing the
+        # whole batch costs.
+        if not bool((value[1] == value[0]).all()):
+            return value, False
+        if value.shape[0] > 2 and not bool((value[2:] == value[:1]).all()):
+            return value, False
+        return value[:1], True
+
     def _dice_logical_pn(self, camera):
         num_frames = int(camera.ray_origin.shape[0])
         source_corners = self.corners.float()
         source_normals = self.normals.float()
+        # Corners and normals collapse together or not at all: a control net is
+        # built from both at once, so collapsing one of a pair would only
+        # broadcast straight back out (and the stacks inside
+        # ``logical_pn_normal_control_points`` mix collapsed and per-frame
+        # terms, which do not stack). Both invariant is also exactly the
+        # condition under which the dice may reuse a patch across frames.
+        collapsed_corners, geometry_static = self._collapse_redundant_frames(
+            source_corners
+        )
+        if geometry_static:
+            collapsed_normals, geometry_static = self._collapse_redundant_frames(
+                source_normals
+            )
+            if geometry_static:
+                source_corners, source_normals = collapsed_corners, collapsed_normals
         device = source_corners.device
         dtype = source_corners.dtype
         cam_o = _expand_frames(_flat_frames(camera.ray_origin, (3,)), num_frames).to(
@@ -1448,6 +1587,7 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
             sp,
             sb,
             output_height,
+            geometry_static,
         )
 
         # Each frame packs its patches back to back at their own diced sizes;
@@ -1496,7 +1636,16 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
                 "logical PN patch/source mismatch: "
                 f"{patch_source.shape[0]} vs {num_patches} patches"
             )
-        if num_patches and max_triangles:
+        # Every patch of a single-surface mesh carries id 0, so the row -> patch
+        # -> surface resolution below has one possible answer. Short-circuit it:
+        # the searchsorted runs over the whole padded [T, max_triangles] grid,
+        # which on a dense mesh is the largest single allocation the dice makes
+        # outside the diced arrays themselves.
+        if self._logical_pn_tri_obj_n == 1:
+            self._logical_pn_tri_obj = torch.zeros(
+                (num_frames, max_triangles), dtype=torch.int32, device=device
+            )
+        elif num_patches and max_triangles:
             ends = counts.cumsum(1)
             cols = torch.arange(max_triangles, device=device)
             patch_of_col = torch.searchsorted(
@@ -1547,18 +1696,38 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
         }
         diced_shader_params = [allocate(v) for v in shader_sources]
         diced_uvs = allocate(uv_source) if uv_source is not None else None
-        padding = torch.ones(
-            (num_frames, max_triangles),
-            dtype=torch.bool,
-            device=device,
-        )
+        # Every attribute the dice writes, paired with the source it reads.
+        # Attributes differ from one another only in width, so the loop below
+        # treats them as one list.
+        attribute_outputs = [(diced_colors, colors)]
+        attribute_outputs += [
+            (diced_surface_params[name], source)
+            for name, source in surface_sources.items()
+        ]
+        attribute_outputs += list(zip(diced_shader_params, shader_sources))
+        if diced_uvs is not None:
+            attribute_outputs.append((diced_uvs, uv_source))
+        # The rows a frame never writes are its tail: the frame's patches are
+        # packed back to back from column 0, so column c is padding exactly
+        # when it is past that frame's diced total. Stating it that way costs
+        # one comparison over the grid, where marking the written rows costs a
+        # fill plus an index_fill_ per chunk.
+        padding = torch.arange(max_triangles, device=device).unsqueeze(
+            0
+        ) >= counts.sum(1).unsqueeze(1)
 
         for level in levels.unique(sorted=True).tolist():
             level = int(level)
-            selected = (levels == level).nonzero()
+            # PATCH-major, not frame-major: ``nonzero`` on the transpose lists
+            # every frame of a patch consecutively, which is what lets the
+            # per-patch dedup below see its duplicates inside one chunk (a
+            # frame-major list puts a patch's frames a whole frame apart, so on
+            # any mesh wider than a chunk no two would ever share one). The
+            # writes are disjoint and ``index_copy_`` does not care about
+            # order, so the diced output is unchanged.
+            selected = (levels == level).t().contiguous().nonzero()
             vertex_uv = subdivision_vertex_uvs(level, device=device, dtype=dtype)
             triangle_indices = subdivision_triangle_indices(level, device=device)
-            corner_uv = subdivision_triangle_uvs(level, device=device, dtype=dtype)
             boundary = subdivision_boundary_map(level, device=device)
             num_triangles = triangle_indices.shape[0]
             columns = torch.arange(num_triangles, device=device)
@@ -1566,27 +1735,48 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
 
             for start in range(0, selected.shape[0], chunk):
                 rows = selected[start : start + chunk]
-                frames, patches = rows[:, 0], rows[:, 1]
+                patches, frames = rows[:, 0], rows[:, 1]
                 edges = edge_levels[frames, patches]
+
+                # A patch's diced geometry depends on the patch and its level,
+                # never on the camera -- the camera only picks the level. So
+                # every frame that dices a patch at this level asks for exactly
+                # the same points, and where the source is frame invariant (a
+                # mesh that does not deform during the batch, which is most of
+                # them) the evaluation is one answer repeated once per frame.
+                # Evaluate it once per distinct patch and fan the rows out with
+                # a gather: one pass, against the twenty-odd a patch evaluation
+                # costs.
+                chunk_rows = _PatchChunk.of(patches, frames, geometry_static)
+
                 # The patch is evaluated once per shared subdivision vertex
                 # (each is a corner of up to six microtriangles), snapped onto
                 # its boundary polylines, and only then expanded to the
-                # triangle-soup layout the packed geometry wants.
+                # triangle-soup layout the packed geometry wants. The snap
+                # happens after the fan-out: it is a function of the boundary
+                # levels, which two frames dicing the same patch need not
+                # share.
+                controls, deduped = chunk_rows.rows_of(control_points, geometry_static)
                 positions = snap_boundary_values(
-                    evaluate_logical_pn(
-                        control_points[frames, patches].unsqueeze(0),
-                        vertex_uv,
-                    )[0],
+                    chunk_rows.fan_out(
+                        evaluate_logical_pn(controls.unsqueeze(0), vertex_uv)[0],
+                        deduped,
+                    ),
                     level,
                     edges,
                     boundary,
                 )
+                normal_controls, deduped = chunk_rows.rows_of(
+                    normal_control_points, geometry_static
+                )
                 vertex_normals = F.normalize(
                     snap_boundary_values(
-                        evaluate_logical_pn_normals(
-                            normal_control_points[frames, patches].unsqueeze(0),
-                            vertex_uv,
-                        )[0],
+                        chunk_rows.fan_out(
+                            evaluate_logical_pn_normals(
+                                normal_controls.unsqueeze(0), vertex_uv
+                            )[0],
+                            deduped,
+                        ),
                         level,
                         edges,
                         boundary,
@@ -1612,34 +1802,14 @@ class LogicalPNTrianglePrimitive(RayTracedTrianglePrimitive):
                 _scatter_diced_rows(
                     diced_normals, vertex_normals[:, triangle_indices], targets
                 )
-                _scatter_diced_rows(
-                    diced_colors,
-                    interpolate_patch_attribute(colors[frames, patches], corner_uv),
-                    targets,
-                )
-                for name, output in diced_surface_params.items():
+                for output, source in attribute_outputs:
                     _scatter_diced_rows(
                         output,
-                        interpolate_patch_attribute(
-                            surface_sources[name][frames, patches], corner_uv
+                        chunk_rows.diced_attribute(
+                            source, vertex_uv, triangle_indices
                         ),
                         targets,
                     )
-                for output, source in zip(diced_shader_params, shader_sources):
-                    _scatter_diced_rows(
-                        output,
-                        interpolate_patch_attribute(source[frames, patches], corner_uv),
-                        targets,
-                    )
-                if diced_uvs is not None:
-                    _scatter_diced_rows(
-                        diced_uvs,
-                        interpolate_patch_attribute(
-                            uv_source[frames, patches], corner_uv
-                        ),
-                        targets,
-                    )
-                padding.view(-1).index_fill_(0, targets, False)
 
         self.corners = diced_corners
         self.normals = diced_normals

--- a/algan/utils/profiling_utils.py
+++ b/algan/utils/profiling_utils.py
@@ -548,7 +548,10 @@ def install_pipeline_hooks():
             ("evaluate_logical_pn", "logical PN:     - evaluate patch"),
             ("evaluate_logical_pn_normals", "logical PN:     - evaluate normals"),
             ("snap_boundary_values", "logical PN:     - snap boundary"),
-            ("interpolate_patch_attribute", "logical PN:     - interpolate attrs"),
+            (
+                "interpolate_patch_vertex_attribute",
+                "logical PN:     - interpolate attrs",
+            ),
             ("subdivision_vertex_uvs", "logical PN:     - subdivision tables"),
             ("subdivision_triangle_indices", "logical PN:     - subdivision tables"),
             ("subdivision_triangle_uvs", "logical PN:     - subdivision tables"),

--- a/benchmarks/_pn_dice_ab.py
+++ b/benchmarks/_pn_dice_ab.py
@@ -63,23 +63,41 @@ SCENARIOS = {
     # name: shape, how many copies batched into one primitive, frames in the
     # batch, camera radius, how far the camera orbits, and how far the mesh
     # deforms over the batch (0 = a mesh that holds still).
-    "static": {"shape": "sphere", "copies": 4, "frames": 16, "radius": 6.0,
-               "orbit": 0.0},
-    "orbit": {"shape": "sphere", "copies": 4, "frames": 32, "radius": 6.0,
-              "orbit": 0.6},
-    "near": {"shape": "sphere", "copies": 1, "frames": 24, "radius": 2.2,
-             "orbit": 0.4},
-    "torus": {"shape": "torus", "copies": 2, "frames": 16, "radius": 5.0,
-              "orbit": 0.5},
-    "cylinder": {"shape": "cylinder", "copies": 2, "frames": 16, "radius": 4.0,
-                 "orbit": 0.3},
-    "cone": {"shape": "cone", "copies": 2, "frames": 12, "radius": 3.0,
-             "orbit": 0.2},
+    "static": {
+        "shape": "sphere",
+        "copies": 4,
+        "frames": 16,
+        "radius": 6.0,
+        "orbit": 0.0,
+    },
+    "orbit": {
+        "shape": "sphere",
+        "copies": 4,
+        "frames": 32,
+        "radius": 6.0,
+        "orbit": 0.6,
+    },
+    "near": {"shape": "sphere", "copies": 1, "frames": 24, "radius": 2.2, "orbit": 0.4},
+    "torus": {"shape": "torus", "copies": 2, "frames": 16, "radius": 5.0, "orbit": 0.5},
+    "cylinder": {
+        "shape": "cylinder",
+        "copies": 2,
+        "frames": 16,
+        "radius": 4.0,
+        "orbit": 0.3,
+    },
+    "cone": {"shape": "cone", "copies": 2, "frames": 12, "radius": 3.0, "orbit": 0.2},
     # A genuinely deforming mesh: no frame shares another's geometry, so every
     # dedup in the fast arm has to disable itself and the two arms should land
     # on the same time as well as the same bytes.
-    "deforming": {"shape": "sphere", "copies": 2, "frames": 12, "radius": 5.0,
-                  "orbit": 0.3, "deform": 0.9},
+    "deforming": {
+        "shape": "sphere",
+        "copies": 2,
+        "frames": 12,
+        "radius": 5.0,
+        "orbit": 0.3,
+        "deform": 0.9,
+    },
 }
 
 
@@ -146,7 +164,9 @@ def reference_dice(self, camera):
             cols.unsqueeze(0).expand(num_frames, -1).contiguous(),
             right=True,
         ).clamp_max(num_patches - 1)
-        self._logical_pn_tri_obj = patch_source[patch_of_col].to(torch.int32).contiguous()
+        self._logical_pn_tri_obj = (
+            patch_source[patch_of_col].to(torch.int32).contiguous()
+        )
     else:
         self._logical_pn_tri_obj = torch.zeros(
             (num_frames, max_triangles), dtype=torch.int32, device=device
@@ -283,7 +303,9 @@ def build_primitive(shape, copies):
 
 def build_camera(frames, radius, orbit, screen_height=486):
     angle = torch.linspace(0.0, orbit, frames)
-    distance = radius * (1.0 + 0.3 * torch.linspace(0.0, 1.0, frames)) if orbit else radius
+    distance = (
+        radius * (1.0 + 0.3 * torch.linspace(0.0, 1.0, frames)) if orbit else radius
+    )
     origins = torch.stack(
         (
             distance * torch.sin(angle),
@@ -395,9 +417,7 @@ def run(name, spec, reps):
     dice_fast(primitive, camera)
     got = diced_arrays(primitive)
 
-    mismatches = [
-        key for key in expected if not bitwise_equal(got[key], expected[key])
-    ]
+    mismatches = [key for key in expected if not bitwise_equal(got[key], expected[key])]
     triangles = expected["corners"].shape[1]
 
     # Alternate the arms so a thermal drift lands on both.

--- a/benchmarks/_pn_dice_ab.py
+++ b/benchmarks/_pn_dice_ab.py
@@ -1,0 +1,437 @@
+"""Logical PN dice: byte-equality and speed against the pre-dedup reference.
+
+``LogicalPNTrianglePrimitive._dice_logical_pn`` turns each logical PN patch
+into flat triangles once per materialized camera frame. The reference arm here
+is the version that shipped before the temporal-coherence work: it rebuilt the
+control nets on every frame of the batch, evaluated every patch once per
+(frame, patch) pair, and interpolated attributes at every microtriangle corner.
+
+Both arms must agree BIT FOR BIT on every diced array -- corners, normals,
+colours, the surface/shader parameters, uvs, the padding mask, the levels and
+the per-row surface ids. The optimizations are all "compute the same value
+fewer times", so anything else is a bug, not a rounding difference.
+
+Arms alternate in one process: cross-process wall clock on this project's
+machines swings ~2x with thermal state, and the dice is a few hundred
+milliseconds, well inside that noise.
+
+Run: <venv-python> benchmarks/_pn_dice_ab.py [--reps N] [scenario ...]
+"""
+
+from __future__ import annotations
+
+import os
+import statistics
+import sys
+import time
+from types import SimpleNamespace
+
+os.environ.setdefault("ALGAN_USE_DAEMON", "0")
+os.environ.setdefault("ALGAN_PREFETCH_BATCHES", "0")
+
+import torch  # noqa: E402
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import torch.nn.functional as F  # noqa: E402
+
+from algan.mobs.shapes_3d import Cone, Cylinder, Sphere, Torus  # noqa: E402
+from algan.rendering.logical_pn import (  # noqa: E402
+    evaluate_logical_pn,
+    evaluate_logical_pn_normals,
+    interpolate_patch_attribute,
+    logical_pn_control_points,
+    logical_pn_edge_control_points,
+    logical_pn_normal_control_points,
+    snap_boundary_values,
+    subdivision_boundary_map,
+    subdivision_triangle_indices,
+    subdivision_triangle_uvs,
+    subdivision_vertex_uvs,
+)
+from algan.rendering.raytracing.primitives import (  # noqa: E402
+    LogicalPNTrianglePrimitive,
+    _scatter_diced_rows,
+)
+from algan.rendering.raytracing.settings import MESH_ID  # noqa: E402
+from algan.rendering.raytracing.utils import _expand_frames, _flat_frames  # noqa: E402
+from algan.scene_manager import SceneManager  # noqa: E402
+
+SHAPES = {"sphere": Sphere, "torus": Torus, "cylinder": Cylinder, "cone": Cone}
+
+SCENARIOS = {
+    # name: shape, how many copies batched into one primitive, frames in the
+    # batch, camera radius, how far the camera orbits, and how far the mesh
+    # deforms over the batch (0 = a mesh that holds still).
+    "static": {"shape": "sphere", "copies": 4, "frames": 16, "radius": 6.0,
+               "orbit": 0.0},
+    "orbit": {"shape": "sphere", "copies": 4, "frames": 32, "radius": 6.0,
+              "orbit": 0.6},
+    "near": {"shape": "sphere", "copies": 1, "frames": 24, "radius": 2.2,
+             "orbit": 0.4},
+    "torus": {"shape": "torus", "copies": 2, "frames": 16, "radius": 5.0,
+              "orbit": 0.5},
+    "cylinder": {"shape": "cylinder", "copies": 2, "frames": 16, "radius": 4.0,
+                 "orbit": 0.3},
+    "cone": {"shape": "cone", "copies": 2, "frames": 12, "radius": 3.0,
+             "orbit": 0.2},
+    # A genuinely deforming mesh: no frame shares another's geometry, so every
+    # dedup in the fast arm has to disable itself and the two arms should land
+    # on the same time as well as the same bytes.
+    "deforming": {"shape": "sphere", "copies": 2, "frames": 12, "radius": 5.0,
+                  "orbit": 0.3, "deform": 0.9},
+}
+
+
+# --------------------------------------------------------------------------
+# The reference dice (the shipped-before version), kept verbatim in structure.
+# --------------------------------------------------------------------------
+def reference_dice(self, camera):
+    num_frames = int(camera.ray_origin.shape[0])
+    source_corners = self.corners.float()
+    source_normals = self.normals.float()
+    device = source_corners.device
+    dtype = source_corners.dtype
+    cam_o = _expand_frames(_flat_frames(camera.ray_origin, (3,)), num_frames).to(device)
+    sp = _expand_frames(_flat_frames(camera.screen_point, (3,)), num_frames).to(device)
+    sb = _expand_frames(_flat_frames(camera.screen_basis, (3, 3)), num_frames).to(
+        device
+    )
+
+    expand = self._expanded_frames
+    control_points = expand(
+        logical_pn_control_points(source_corners, source_normals),
+        num_frames,
+        "logical PN corners",
+    )
+    normal_control_points = expand(
+        logical_pn_normal_control_points(source_corners, source_normals),
+        num_frames,
+        "logical PN normals",
+    )
+    edge_controls = expand(
+        logical_pn_edge_control_points(source_corners, source_normals),
+        num_frames,
+        "logical PN edges",
+    )
+    output_height = getattr(camera, "output_screen_height", camera.screen_height)
+    levels, edge_levels = self._required_subdivision_levels(
+        control_points, edge_controls, cam_o, sp, sb, output_height
+    )
+
+    counts = self._triangle_counts(levels)
+    offsets = counts.cumsum(1) - counts
+    max_triangles = int(counts.sum(1).amax().item()) if counts.numel() else 0
+
+    num_patches = counts.shape[1] if counts.ndim > 1 else 0
+    counts_src = getattr(self, "_rt_obj_counts", None)
+    obj_ids = getattr(self, "_rt_obj_ids", None) if MESH_ID else None
+    if obj_ids is not None:
+        patch_source = obj_ids.reshape(-1).to(device=device, dtype=torch.int32)
+        self._logical_pn_tri_obj_n = int(self._rt_obj_ids_n)
+    elif counts_src:
+        patch_source = torch.repeat_interleave(
+            torch.arange(len(counts_src), dtype=torch.int32, device=device),
+            torch.tensor(counts_src, dtype=torch.int64, device=device),
+        )
+        self._logical_pn_tri_obj_n = len(counts_src)
+    else:
+        patch_source = torch.zeros((num_patches,), dtype=torch.int32, device=device)
+        self._logical_pn_tri_obj_n = 1
+    if num_patches and max_triangles:
+        ends = counts.cumsum(1)
+        cols = torch.arange(max_triangles, device=device)
+        patch_of_col = torch.searchsorted(
+            ends.contiguous(),
+            cols.unsqueeze(0).expand(num_frames, -1).contiguous(),
+            right=True,
+        ).clamp_max(num_patches - 1)
+        self._logical_pn_tri_obj = patch_source[patch_of_col].to(torch.int32).contiguous()
+    else:
+        self._logical_pn_tri_obj = torch.zeros(
+            (num_frames, max_triangles), dtype=torch.int32, device=device
+        )
+
+    colors = expand(self.colors.float(), num_frames, "logical PN colors")
+    surface_sources = {
+        name: expand(getattr(self, name), num_frames, f"logical PN {name}")
+        for name in self._surface_params
+    }
+    shader_sources = [
+        expand(value, num_frames, "logical PN shader parameter")
+        for value in self.shader_param_values
+    ]
+    uv_source = expand(self.uvs, num_frames, "logical PN UVs")
+
+    def allocate(values):
+        return torch.zeros(
+            (num_frames, max_triangles, 3, values.shape[-1]),
+            device=values.device,
+            dtype=values.dtype,
+        )
+
+    diced_corners = allocate(source_corners)
+    diced_normals = allocate(source_normals)
+    diced_colors = allocate(colors)
+    diced_surface_params = {
+        name: allocate(source) for name, source in surface_sources.items()
+    }
+    diced_shader_params = [allocate(v) for v in shader_sources]
+    diced_uvs = allocate(uv_source) if uv_source is not None else None
+    padding = torch.ones((num_frames, max_triangles), dtype=torch.bool, device=device)
+
+    for level in levels.unique(sorted=True).tolist():
+        level = int(level)
+        selected = (levels == level).nonzero()
+        vertex_uv = subdivision_vertex_uvs(level, device=device, dtype=dtype)
+        triangle_indices = subdivision_triangle_indices(level, device=device)
+        corner_uv = subdivision_triangle_uvs(level, device=device, dtype=dtype)
+        boundary = subdivision_boundary_map(level, device=device)
+        num_triangles = triangle_indices.shape[0]
+        columns = torch.arange(num_triangles, device=device)
+        chunk = max(1, int(self.max_scratch_triangles) // num_triangles)
+
+        for start in range(0, selected.shape[0], chunk):
+            rows = selected[start : start + chunk]
+            frames, patches = rows[:, 0], rows[:, 1]
+            edges = edge_levels[frames, patches]
+            positions = snap_boundary_values(
+                evaluate_logical_pn(
+                    control_points[frames, patches].unsqueeze(0), vertex_uv
+                )[0],
+                level,
+                edges,
+                boundary,
+            )
+            vertex_normals = F.normalize(
+                snap_boundary_values(
+                    evaluate_logical_pn_normals(
+                        normal_control_points[frames, patches].unsqueeze(0), vertex_uv
+                    )[0],
+                    level,
+                    edges,
+                    boundary,
+                ),
+                p=2,
+                dim=-1,
+            )
+            targets = (
+                frames.unsqueeze(1) * max_triangles
+                + offsets[frames, patches].unsqueeze(1)
+                + columns
+            ).reshape(-1)
+
+            _scatter_diced_rows(diced_corners, positions[:, triangle_indices], targets)
+            _scatter_diced_rows(
+                diced_normals, vertex_normals[:, triangle_indices], targets
+            )
+            _scatter_diced_rows(
+                diced_colors,
+                interpolate_patch_attribute(colors[frames, patches], corner_uv),
+                targets,
+            )
+            for name, output in diced_surface_params.items():
+                _scatter_diced_rows(
+                    output,
+                    interpolate_patch_attribute(
+                        surface_sources[name][frames, patches], corner_uv
+                    ),
+                    targets,
+                )
+            for output, source in zip(diced_shader_params, shader_sources):
+                _scatter_diced_rows(
+                    output,
+                    interpolate_patch_attribute(source[frames, patches], corner_uv),
+                    targets,
+                )
+            if diced_uvs is not None:
+                _scatter_diced_rows(
+                    diced_uvs,
+                    interpolate_patch_attribute(uv_source[frames, patches], corner_uv),
+                    targets,
+                )
+            padding.view(-1).index_fill_(0, targets, False)
+
+    self.corners = diced_corners
+    self.normals = diced_normals
+    self.colors = diced_colors
+    for name, values in diced_surface_params.items():
+        setattr(self, name, values)
+    self.shader_param_values = diced_shader_params
+    self.uvs = diced_uvs
+    self._logical_pn_padding = padding
+    self._logical_pn_subdivision_levels = levels
+    self._logical_pn_edge_levels = edge_levels
+
+
+# --------------------------------------------------------------------------
+# Scenario construction
+# --------------------------------------------------------------------------
+def build_primitive(shape, copies):
+    SceneManager.reset()
+    mob = SHAPES[shape]()
+    mob.spawn()
+    primitives = mob.get_render_primitives()
+    primitives = (
+        list(primitives) if isinstance(primitives, (list, tuple)) else [primitives]
+    )
+    members = [p for p in primitives if isinstance(p, LogicalPNTrianglePrimitive)]
+    if not members:
+        raise RuntimeError(f"{shape} produced no logical PN primitive")
+    return LogicalPNTrianglePrimitive(triangle_collection=members * copies)
+
+
+def build_camera(frames, radius, orbit, screen_height=486):
+    angle = torch.linspace(0.0, orbit, frames)
+    distance = radius * (1.0 + 0.3 * torch.linspace(0.0, 1.0, frames)) if orbit else radius
+    origins = torch.stack(
+        (
+            distance * torch.sin(angle),
+            torch.zeros_like(angle),
+            -distance * torch.cos(angle),
+        ),
+        dim=-1,
+    ).unsqueeze(1)
+    forward = -origins / origins.norm(dim=-1, keepdim=True)
+    up = torch.tensor([0.0, 1.0, 0.0]).expand(frames, 3)
+    right = torch.cross(up, forward.squeeze(1), dim=-1)
+    right = right / right.norm(dim=-1, keepdim=True)
+    return SimpleNamespace(
+        ray_origin=origins,
+        screen_point=origins + forward,
+        screen_basis=torch.stack((right, up, forward.squeeze(1)), dim=1),
+        screen_width=864,
+        screen_height=screen_height,
+        output_screen_width=864,
+        output_screen_height=screen_height,
+        analytic_raster=False,
+    )
+
+
+ATTRIBUTES = ("corners", "normals", "colors", "uvs")
+
+
+def source_state(primitive, frames, deform=0.0):
+    """The primitive's source arrays, materialized one row per frame.
+
+    A real render hands the dice per-frame rows whether or not the mob moved,
+    which is the whole point of the collapse the fast arm does; building the
+    scenario any other way would measure a case that never happens.
+    """
+    state = {}
+    for name in (*ATTRIBUTES, *primitive._surface_params):
+        value = getattr(primitive, name, None)
+        if value is None:
+            continue
+        if value.shape[0] == 1:
+            value = value.expand(frames, *value.shape[1:])
+        state[name] = value.contiguous()
+    state["shader_param_values"] = [
+        (v.expand(frames, *v.shape[1:]) if v.shape[0] == 1 else v).contiguous()
+        for v in primitive.shader_param_values
+    ]
+    if deform:
+        offsets = torch.linspace(0.0, deform, frames).view(-1, 1, 1, 1)
+        state["corners"] = (state["corners"] + offsets).contiguous()
+    return state
+
+
+def restore(primitive, state):
+    for name, value in state.items():
+        if name == "shader_param_values":
+            primitive.shader_param_values = [v.clone() for v in value]
+        else:
+            setattr(primitive, name, value.clone())
+
+
+def diced_arrays(primitive):
+    out = {
+        "corners": primitive.corners,
+        "normals": primitive.normals,
+        "colors": primitive.colors,
+        "uvs": primitive.uvs,
+        "padding": primitive._logical_pn_padding,
+        "levels": primitive._logical_pn_subdivision_levels,
+        "edge_levels": primitive._logical_pn_edge_levels,
+        "tri_obj": primitive._logical_pn_tri_obj,
+    }
+    for name in primitive._surface_params:
+        out[name] = getattr(primitive, name)
+    for index, value in enumerate(primitive.shader_param_values):
+        out[f"shader_param_{index}"] = value
+    return {k: v for k, v in out.items() if v is not None}
+
+
+def bitwise_equal(a, b):
+    if a.shape != b.shape or a.dtype != b.dtype:
+        return False
+    if a.dtype.is_floating_point:
+        bits = torch.int32 if a.dtype == torch.float32 else torch.int64
+        return torch.equal(a.contiguous().view(bits), b.contiguous().view(bits))
+    return torch.equal(a, b)
+
+
+def time_dice(primitive, state, camera, dice, reps):
+    samples = []
+    for _ in range(reps):
+        restore(primitive, state)
+        start = time.perf_counter()
+        dice(primitive, camera)
+        samples.append(time.perf_counter() - start)
+    return samples
+
+
+def run(name, spec, reps):
+    primitive = build_primitive(spec["shape"], spec["copies"])
+    frames = spec["frames"]
+    state = source_state(primitive, frames, spec.get("deform", 0.0))
+    camera = build_camera(frames, spec["radius"], spec["orbit"])
+    dice_fast = LogicalPNTrianglePrimitive._dice_logical_pn
+
+    restore(primitive, state)
+    reference_dice(primitive, camera)
+    expected = {k: v.clone() for k, v in diced_arrays(primitive).items()}
+    restore(primitive, state)
+    dice_fast(primitive, camera)
+    got = diced_arrays(primitive)
+
+    mismatches = [
+        key for key in expected if not bitwise_equal(got[key], expected[key])
+    ]
+    triangles = expected["corners"].shape[1]
+
+    # Alternate the arms so a thermal drift lands on both.
+    reference_times, fast_times = [], []
+    for _ in range(reps):
+        reference_times += time_dice(primitive, state, camera, reference_dice, 1)
+        fast_times += time_dice(primitive, state, camera, dice_fast, 1)
+
+    reference = min(reference_times)
+    fast = min(fast_times)
+    status = "BIT-IDENTICAL" if not mismatches else f"MISMATCH {mismatches}"
+    print(
+        f"{name:<10} {frames:>3}f x {expected['levels'].shape[1]:>5}patch "
+        f"-> {triangles:>6} tri/frame | "
+        f"reference {reference * 1e3:8.1f} ms  fast {fast * 1e3:8.1f} ms  "
+        f"{reference / fast:5.2f}x  (median {statistics.median(reference_times) * 1e3:.1f}"
+        f" / {statistics.median(fast_times) * 1e3:.1f})  {status}"
+    )
+    return not mismatches
+
+
+def main(argv):
+    reps = 5
+    if "--reps" in argv:
+        index = argv.index("--reps")
+        reps = int(argv[index + 1])
+        del argv[index : index + 2]
+    names = argv or list(SCENARIOS)
+    ok = True
+    for name in names:
+        ok &= run(name, SCENARIOS[name], reps)
+    print("\nall arms byte-identical" if ok else "\nBYTE MISMATCH -- see above")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/unit_tests/test_logical_pn_tessellation.py
+++ b/tests/unit_tests/test_logical_pn_tessellation.py
@@ -10,6 +10,8 @@ from algan.mobs.shapes_3d import Cone, Cylinder, Sphere, Torus
 from algan.rendering.logical_pn import (
     evaluate_logical_pn,
     evaluate_logical_pn_normals,
+    interpolate_patch_attribute,
+    interpolate_patch_vertex_attribute,
     logical_pn_control_points,
     logical_pn_edge_control_points,
     logical_pn_normal_control_points,
@@ -475,6 +477,96 @@ def test_boundary_snap_is_a_no_op_when_the_levels_agree():
     snapped = snap_boundary_values(values, 2, levels, boundary)
     changed = (snapped != values).any(-1).any(-1)
     assert changed.tolist() == [False, False, True, False, False]
+
+
+def _materialized_per_frame(primitive, num_frames):
+    """Give ``primitive`` one source row per frame, as materialization does.
+
+    A mob that does not move still reaches the dice as ``num_frames``
+    byte-identical rows -- the ``[1, ...]`` sources these fixtures build
+    otherwise are not what a real render hands it.
+    """
+    for name in ("corners", "normals", "colors", *primitive._surface_params):
+        value = getattr(primitive, name, None)
+        if value is not None and value.shape[0] == 1:
+            setattr(
+                primitive, name, value.expand(num_frames, *value.shape[1:]).contiguous()
+            )
+    if primitive.uvs is not None and primitive.uvs.shape[0] == 1:
+        primitive.uvs = primitive.uvs.expand(
+            num_frames, *primitive.uvs.shape[1:]
+        ).contiguous()
+    primitive.shader_param_values = [
+        value.expand(num_frames, *value.shape[1:]).contiguous()
+        if value.shape[0] == 1
+        else value
+        for value in primitive.shader_param_values
+    ]
+    return primitive
+
+
+def test_vertex_attribute_interpolation_matches_the_per_corner_form():
+    # The dice interpolates attributes on the shared subdivision vertices and
+    # gathers them through the triangle indices, which is only sound because a
+    # microtriangle's corners ARE those vertices.
+    torch.manual_seed(0)
+    values = torch.randn(23, 3, 4)
+    for level in range(4):
+        corner_uv = subdivision_triangle_uvs(
+            level, device=values.device, dtype=values.dtype
+        )
+        vertex_uv = subdivision_vertex_uvs(
+            level, device=values.device, dtype=values.dtype
+        )
+        indices = subdivision_triangle_indices(level, device=values.device)
+        assert torch.equal(
+            interpolate_patch_vertex_attribute(values, vertex_uv)[:, indices],
+            interpolate_patch_attribute(values, corner_uv),
+        )
+
+
+def test_frame_invariant_sources_dice_to_the_same_values(monkeypatch):
+    # A mesh that does not move arrives as N identical source rows, and the
+    # dice collapses them: one control net instead of N, and one evaluation per
+    # distinct patch instead of one per (frame, patch). Nothing it writes may
+    # move as a result.
+    corners, normals = _curved_patch_inputs()
+    two_patches = (
+        torch.stack((corners, _shifted(corners, (0.0, 0.0, 240.0)))),
+        torch.stack((normals, normals)),
+    )
+    frames = [-30.0, -6.0, -3.0]
+
+    def fixture():
+        return _materialized_per_frame(
+            _logical_patches(*two_patches, render_tolerance=0.0005), len(frames)
+        )
+
+    shared, per_frame = fixture(), fixture()
+    with monkeypatch.context() as patch:
+        # Report every source as frame-varying: the pre-collapse code path.
+        patch.setattr(
+            LogicalPNTrianglePrimitive,
+            "_collapse_redundant_frames",
+            staticmethod(lambda value: (value, False)),
+        )
+        per_frame._dice_logical_pn(_camera(frames, device=per_frame.corners.device))
+    shared._dice_logical_pn(_camera(frames, device=shared.corners.device))
+
+    levels = shared._logical_pn_subdivision_levels
+    assert levels.unique().numel() > 1, (
+        "the fixture must dice its patches at more than one level"
+    )
+    assert shared._logical_pn_padding.any(), "the fixture must pad some frames"
+    for name in ("corners", "normals", "colors", *shared._surface_params):
+        assert torch.equal(getattr(shared, name), getattr(per_frame, name)), name
+    for name in (
+        "_logical_pn_padding",
+        "_logical_pn_subdivision_levels",
+        "_logical_pn_edge_levels",
+        "_logical_pn_tri_obj",
+    ):
+        assert torch.equal(getattr(shared, name), getattr(per_frame, name)), name
 
 
 def test_geometry_tolerance_is_absolute_at_construction_scale():


### PR DESCRIPTION
## What and why

A patch's diced geometry is a function of the patch and its subdivision level and nothing else — the camera only decides the level. The dice did not use that. Materialization hands it one source row per frame whether or not the mob moved, so a mesh that holds still arrives as T byte-identical copies of one geometry and was diced T times over: T control-net builds producing T identical answers, T uploads of the same control points to the criterion kernels, and T evaluations of each patch at the same parameters. Measured on a static two-mob scene, the dice receives `corners` of shape `[4, 508, 3, 3]` with one distinct frame in it. (`_dice_logical_pn`'s comment claimed a static mesh already kept one copy — true only if the source arrives `[1, N, …]`, which in a render it never does.)

So: detect the duplicate frames and drop them; walk the `(frame, patch)` work list patch-major where that is useful, so a patch's frames land in one chunk and its position and normal patches are evaluated once and fanned out with a gather; and interpolate attributes on the shared subdivision vertices rather than at every microtriangle corner, which is the same arithmetic over a sixth as many points because the corners *are* those vertices. The same sharing is applied to the torch fallback of the patch-flatness criterion, which had the same per-frame redundancy, and deliberately not to the kernel path, which keeps its samples in registers and has nothing to share.

Two smaller things while the file was open: the padding mask is stated directly as "past this frame's diced total" instead of being built by filling every row and then clearing the written ones, and the row→surface `searchsorted` — which runs over the whole padded `[T, max_triangles]` grid — is skipped for a mesh that has only one surface, where its answer can only be zero.

**What it is worth, measured inside real renders** rather than on a synthetic mesh, by running both implementations on every dice call with the same inputs and alternating which goes first:

| scene | dice calls | frame-invariant calls | deforming calls | whole dice |
| --- | --- | --- | --- | --- |
| `solids_and_camera` | 10 | **1.37x** (2 calls, 22% of dice time) | 0.98x | **1.05x** |
| `materials_and_lighting` | 38 | **1.27x** (20 calls, 60%) | 1.01x | **1.15x** |
| `complex_hierarchy_become` | 4 | — (one 10 ms call) | 1.14x | **1.14x** |

The isolated benchmark reports 1.13–1.33x for a mesh that holds still while the camera moves; **that is not the render-level figure and should not be quoted as one.** A mob's `corners` are world-space, so "frame invariant" means the mob does not move at all during the batch, and a scene about motion spends most of its dice time on meshes that do. Batches here are 101 and 138 frames, so where it does fire the redundancy removed is large.

Measuring in a real render also caught something the synthetic benchmark hid, and it is why the second commit exists. Patch-major ordering is what lets the dedup find its duplicates, but consecutive rows then write a whole frame apart in the output instead of in one run, and read their control points the same way. On the deforming half of `materials_and_lighting`'s calls — nothing to dedup, all cost — that measured **0.965x**, while the isolated benchmark's smaller deforming mesh reported a harmless 1.03x. The ordering is now gated on the same frame-invariance condition the search's `share_patches` uses; those calls measure 1.005x and the scene's whole dice goes 1.122x → 1.148x.

Also recorded in `DESIGN_optimization_targets.md`: two things measured and **not** taken. The `allocate()` zero-fills that document nominated as T4's remaining half are 4% of the write-out, not its expensive part. And deduping the *attribute* interpolation is a net 0.86x — a three-corner barycentric blend is cheaper to recompute than to fan back out, so only the patch evaluation clears that bar.

## Rendered output

**Unchanged.** Every optimization here computes the same value fewer times, so anything else would be a bug rather than a rounding difference, and that is asserted rather than assumed:

- All six `tests/full_renders` scenes match their committed **CPU** baselines on this machine. That is a real check here and not a vacuous one: before making any change I re-baselined this machine against the base commit and it rewrote every file **byte-identically**, so the committed CPU set is this machine's own output rather than a tolerance pass.
- `benchmarks/_pn_dice_ab.py` (new) runs the pre-change dice beside the current one in one process and compares every diced array **bit for bit** — corners, normals, colours, the four surface parameters, shader parameters, uvs, the padding mask, both level arrays and the per-row surface ids — across static, orbiting, multi-level, multi-surface and deforming meshes. All arms bit-identical.

No baselines were regenerated; `expected_outputs_cpu/` and `expected_outputs_cuda/` are untouched.

## Verification

Everything below ran on the **CPU-only cloud container** (4 vCPU, no GPU):

- `pytest -q tests/full_renders` — 7 passed. Run after the change; also run before it to establish the baselines above.
- `pytest -q tests/unit_tests` — 1148 passed, 92 skipped.
- `pytest -q --fast` — 211 passed.
- `benchmarks/_pn_dice_ab.py --reps 8` — all seven meshes bit-identical, timings above.
- `ruff check --no-fix` — clean.

Two new tests in `tests/unit_tests/test_logical_pn_tessellation.py`, both unmarked (they only fail when the dice itself changes): one asserts the per-vertex attribute interpolation is exactly the per-corner one gathered through the triangle indices, the other dices a multi-level fixture with the frame collapse monkeypatched off and asserts every diced array, both level arrays, the padding mask and the surface ids come out equal.

**What I could not check here:** anything CUDA. This machine has no GPU, so the criterion-kernel path is never taken — which means the two places this change touches it are unexercised: `share_patches` is forced off when the kernel is active, and `_frame_broadcast_base` now hands the kernels a stride-0 control net (one frame) where it used to hand them T contiguous copies. The kernel's own `t * frame_stride` indexing already handles stride 0 and is unchanged, but it should have a CUDA run before this is trusted there. CPU/CUDA divergence is likewise uncheckable from here.

## Docs

No public API touched — `logical_pn` is in `_INTERNAL_EXPORT_MODULES`, and nothing in `algan.__all__` changed, so no tutorial or reference page moves. `DESIGN_optimization_targets.md` is updated: T4's status row and section now describe what shipped, carry the in-render numbers rather than the synthetic ones and say why they differ, record the two rejected ideas above, and point the "what is left" list at the remaining item this work exposed — on CPU the dice is 65–85% *level search*, because the fused criterion kernels are gated on a CUDA render device. Lifting them onto Taichi's x64 backend is the obvious next move and is written up with its cost: `fast_math` would flip borderline levels and move the CPU baselines exactly as T1 moved the CUDA ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ycpJqKeVhT9R3VwECdgG8

---
_Generated by [Claude Code](https://claude.ai/code/session_017ycpJqKeVhT9R3VwECdgG8)_